### PR TITLE
chore: add a Storybook addon to ease working with OUIA ids

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,6 +9,7 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
     "@storybook/addon-a11y",
+    "./ouia-addon/preset",
   ],
   features: {
     interactionsDebugger: true,

--- a/.storybook/ouia-addon/addDecorator.js
+++ b/.storybook/ouia-addon/addDecorator.js
@@ -1,0 +1,3 @@
+import { withOUIA } from "./withOUIA";
+
+export const decorators = [withOUIA];

--- a/.storybook/ouia-addon/constants.js
+++ b/.storybook/ouia-addon/constants.js
@@ -1,0 +1,9 @@
+export const ADDON_ID = "ouia-panel";
+export const TOOL_ID = `${ADDON_ID}/tool`;
+export const PANEL_ID = `${ADDON_ID}/panel`;
+export const TAB_ID = `${ADDON_ID}/tab`;
+export const PARAM_KEY = `ouia`;
+
+export const EVENTS = {
+  RENDERED: `${ADDON_ID}/rendered`,
+};

--- a/.storybook/ouia-addon/preset.js
+++ b/.storybook/ouia-addon/preset.js
@@ -1,0 +1,13 @@
+function managerEntries(entry = []) {
+  return [...entry, require.resolve("./register.tsx")]; //👈 Addon implementation
+}
+
+function config(entry = [], { addDecorator = true } = {}) {
+  const c = [];
+  if (addDecorator) {
+    c.push(require.resolve("./addDecorator"));
+  }
+  return [...entry, ...c];
+}
+
+module.exports = { managerEntries, config };

--- a/.storybook/ouia-addon/register.tsx
+++ b/.storybook/ouia-addon/register.tsx
@@ -1,0 +1,133 @@
+import {
+  TableComposable,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+} from "@patternfly/react-table";
+import { addons, types } from "@storybook/addons";
+import { useChannel, useAddonState } from "@storybook/api";
+import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/react-core/dist/styles/base.css";
+import React, { useState, VoidFunctionComponent } from "react";
+import { ADDON_ID, EVENTS, PANEL_ID } from "./constants";
+import {
+  Alert,
+  AlertActionLink,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  TextContent,
+} from "@patternfly/react-core";
+
+export interface PanelProp {
+  active: boolean;
+}
+
+export interface OUIANode {
+  id: string;
+  type: string;
+  selector: string;
+}
+
+// give a unique name for the panel
+const OUIAPanel: React.FunctionComponent<PanelProp> = ({
+  active,
+  ...props
+}) => {
+  const [nodes, setNodes] = useAddonState<OUIANode[]>(ADDON_ID, []);
+
+  useChannel({
+    [EVENTS.RENDERED]: function ({ nodes }) {
+      setNodes(nodes);
+    },
+  });
+
+  if (!active) return null;
+  return (
+    <TableComposable>
+      <Thead>
+        <Tr>
+          <Th hasRightBorder colSpan={2}>
+            OUIA
+          </Th>
+          <Th>Pendo</Th>
+        </Tr>
+        <Tr>
+          <Th isSubheader>OUIA id</Th>
+          <Th isSubheader>OUIA type</Th>
+
+          <Th isSubheader>Selector</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {nodes.map((node, rowIndex) => (
+          <Tr key={rowIndex}>
+            <Td>{node.id}</Td>
+            <Td>{node.type}</Td>
+            <Td>
+              <Selector selector={node.selector} />
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </TableComposable>
+  );
+};
+
+const Selector: VoidFunctionComponent<{ selector: string }> = ({
+  selector,
+}) => {
+  const isSelectorSafe = !selector.includes("OUIA-Generated");
+  const [showSelector, setShowSelector] = useState(isSelectorSafe);
+  return (
+    <>
+      {!isSelectorSafe && (
+        <Alert
+          variant="warning"
+          isInline
+          title="Selector not safe to be used on Pendo!"
+          actionLinks={
+            <>
+              <AlertActionLink onClick={() => setShowSelector(true)}>
+                I understand, show anyway
+              </AlertActionLink>
+            </>
+          }
+        >
+          <TextContent>
+            <p>
+              This selector contains references to automatically generated OUIA
+              ids. These ids are generated when the component is added on the
+              page. It is <strong>very likely</strong> these ids will be
+              different in the final application.
+            </p>
+            <p>
+              It is advised <strong>not</strong> to use this selector to track
+              the feature on Pendo. Open an issue to ask the developers to
+              statically define the id.
+            </p>
+          </TextContent>
+        </Alert>
+      )}
+      {showSelector && (
+        <ClipboardCopy
+          isReadOnly
+          hoverTip="Copy"
+          clickTip="Copied"
+          variant={ClipboardCopyVariant.expansion}
+        >
+          {selector}
+        </ClipboardCopy>
+      )}
+    </>
+  );
+};
+
+addons.register(ADDON_ID, (api) => {
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title: "OUIA",
+    render: ({ active, key }) => <OUIAPanel active={active} key={key} />,
+  });
+});

--- a/.storybook/ouia-addon/withOUIA.js
+++ b/.storybook/ouia-addon/withOUIA.js
@@ -1,0 +1,54 @@
+const { addons, makeDecorator } = require("@storybook/addons");
+const { useEffect } = require("react");
+const { EVENTS } = require("./constants");
+
+const withOUIA = makeDecorator({
+  name: "withOUIA",
+  parameterName: "ouia",
+  wrapper: (storyFn, context, { id }) => {
+    const channel = addons.getChannel();
+
+    const updateNodes = () => {
+      const els = document.querySelectorAll("[data-ouia-component-id]");
+      const nodes = Array.from(els).map((el) => {
+        return {
+          id: el.attributes.getNamedItem("data-ouia-component-id").value,
+          type: el.attributes.getNamedItem("data-ouia-component-type").value,
+          selector: generateSelector(el),
+        };
+      });
+      channel.emit(EVENTS.RENDERED, {
+        nodes: Array.from(nodes),
+      });
+    };
+
+    useEffect(() => {
+      const interval = setInterval(updateNodes, 1000);
+      return () => clearInterval(interval);
+    }, []);
+    return storyFn(context);
+  },
+});
+
+function generateSelector(context) {
+  let pathSelector = "",
+    localName;
+
+  if (context == "null") throw "not an dom reference";
+
+  while (context.tagName) {
+    // selector path
+
+    const ouiaID = context.attributes.getNamedItem("data-ouia-component-id");
+
+    if (ouiaID) {
+      pathSelector =
+        `[data-ouia-component-id=${ouiaID.value}]` +
+        (pathSelector ? " " + pathSelector : "");
+    }
+    context = context.parentNode;
+  }
+  return pathSelector;
+}
+
+module.exports = { withOUIA };

--- a/.storybook/ouia-helper.css
+++ b/.storybook/ouia-helper.css
@@ -1,0 +1,31 @@
+.show-ouia [data-ouia-component-id] {
+  outline: 1px solid var(--pf-global--palette--cyan-50);
+}
+
+.show-ouia [data-ouia-component-id]::before {
+  content: attr(data-ouia-component-id);
+  position: absolute;
+  font-size: 0.75rem;
+  font-weight: normal;
+  display: inline-flex;
+  align-items: center;
+  background: var(--pf-global--palette--cyan-50);
+  color: var(--pf-global--default-color--300);
+  display: inline-flex;
+  padding-top: var(--pf-global--spacer--xs);
+  padding-right: var(--pf-global--spacer--sm);
+  padding-bottom: var(--pf-global--spacer--xs);
+  padding-left: var(--pf-global--spacer--sm);
+  border-radius: var(--pf-global--BorderRadius--lg);
+  border: 1px solid ;
+  border-radius: 30em;
+  z-index: 100;
+}
+
+.show-ouia [data-ouia-component-id*=OUIA-Generated] {
+  outline-color: rgb(201, 25, 11);
+}
+.show-ouia [data-ouia-component-id*=OUIA-Generated]::before {
+  background: var(--pf-global--palette--red-50);
+  border-color: rgb(201, 25, 11);
+}

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,5 +8,5 @@
   .innerZoomElementWrapper {
     /* this will make modals render inside the inline preview in docs mode */
     transform: scale(1);
-  }
+  }  
 </style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/react-core/dist/styles/base.css";
 import "@patternfly/patternfly/utilities/Accessibility/accessibility.css";
 import "@patternfly/patternfly/utilities/BackgroundColor/BackgroundColor.css";
 import "@patternfly/patternfly/utilities/Display/display.css";
@@ -6,8 +7,9 @@ import "@patternfly/patternfly/utilities/Flex/flex.css";
 import "@patternfly/patternfly/utilities/Sizing/sizing.css";
 import "@patternfly/patternfly/utilities/Spacing/spacing.css";
 import "@patternfly/patternfly/utilities/Text/text.css";
+import "./ouia-helper.css";
 import { inspect } from "@xstate/inspect";
-import React from "react";
+import React, { useEffect } from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { AppServicesLoading, I18nProvider } from "../src";
 
@@ -26,6 +28,7 @@ export const parameters = {
     },
   },
   previewTabs: { "storybook/docs/panel": { index: -1 } },
+  ouia: "false",
   locale: "en_US",
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -114,10 +117,25 @@ export const globalTypes = {
       ],
     },
   },
+  ouia: {
+    name: "OUIA",
+    description: "Show OUIA ids used in the component",
+    defaultValue: "false",
+    toolbar: {
+      items: [
+        { value: "true", title: "Show OUIA ids" },
+        { value: "false", title: "Hide OUIA ids" },
+      ],
+      showName: true,
+    },
+  },
 };
 
 export const decorators = [
   (Story, { globals }) => {
+    useEffect(() => {
+      document.body.classList.toggle("show-ouia", JSON.parse(globals.ouia));
+    }, [globals.ouia]);
     return (
       <Router>
         <I18nProvider


### PR DESCRIPTION
Adds an addon to Storybook to visually inspect the OUIA ids in use in the story.

Green ids are statically set, so safe to use. Red ids are autogenerated, so they probably shouldn't be used.

Ids are also listed in a panel called OUIA, with a selector that can be copy-pasted directly to Pendo and that takes into account parent OUIA ids if present.

![Kapture 2021-12-20 at 16 34 11](https://user-images.githubusercontent.com/966316/146793547-4ad4bf01-ad32-47c6-bf18-cd5d669af264.gif)
