### PR TITLE
fix: add reached max limit for supported regions

### DIFF
--- a/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.stories.tsx
+++ b/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.stories.tsx
@@ -348,3 +348,61 @@ function makeAvailableProvidersAndDefaults(
     };
   };
 }
+
+export const LoadSupportedRegionsAndDisabledUnsupported = Template.bind({});
+LoadSupportedRegionsAndDisabledUnsupported.args = {
+  getAvailableProvidersAndDefaults: makeAvailableProvidersAndDefaults(
+    {
+      instanceAvailability: "trial",
+      defaultAZ: "multi",
+      defaultProvider: "aws",
+      providers: ["aws"],
+    },
+    PROVIDERS.map((p) => ({
+      ...p,
+      regions: [
+        {
+          id: "us-east-1",
+          displayName: "US East, N. Virginia",
+        },
+        {
+          id: "eu-west-1",
+          displayName: "EU, Ireland (not supported)",
+          isDisabled: true,
+        },
+      ],
+    }))
+  ),
+} as CreateKafkaInstanceProps;
+
+export const ReachedMaxLimitForTrialInstanceForSupportedRegions = Template.bind(
+  {}
+);
+ReachedMaxLimitForTrialInstanceForSupportedRegions.args = {
+  getAvailableProvidersAndDefaults: makeAvailableProvidersAndDefaults(
+    {
+      instanceAvailability: "trial",
+      defaultProvider: "aws",
+      providers: ["aws"],
+      defaultAZ: "multi",
+    },
+    PROVIDERS.map((p) => ({
+      ...p,
+      regions: [],
+    }))
+  ),
+} as CreateKafkaInstanceProps;
+
+export const ReachedMaxLimitForSupportedRegionAfterSubmitCreateForm =
+  Template.bind({});
+ReachedMaxLimitForSupportedRegionAfterSubmitCreateForm.args = {
+  getAvailableProvidersAndDefaults: makeAvailableProvidersAndDefaults({
+    instanceAvailability: "trial",
+    defaultAZ: "multi",
+    defaultProvider: "aws",
+    providers: ["aws"],
+  }),
+  onCreate: (_data, _onSuccess, onError) => onError("trial-unavailable"),
+} as CreateKafkaInstanceProps;
+
+ReachedMaxLimitForSupportedRegionAfterSubmitCreateForm.play = sampleSubmit;

--- a/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.stories.tsx
+++ b/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.stories.tsx
@@ -367,7 +367,7 @@ LoadSupportedRegionsAndDisabledUnsupported.args = {
         },
         {
           id: "eu-west-1",
-          displayName: "EU, Ireland (not supported)",
+          displayName: "EU, Ireland",
           isDisabled: true,
         },
       ],
@@ -392,17 +392,3 @@ ReachedMaxLimitForTrialInstanceForSupportedRegions.args = {
     }))
   ),
 } as CreateKafkaInstanceProps;
-
-export const ReachedMaxLimitForSupportedRegionAfterSubmitCreateForm =
-  Template.bind({});
-ReachedMaxLimitForSupportedRegionAfterSubmitCreateForm.args = {
-  getAvailableProvidersAndDefaults: makeAvailableProvidersAndDefaults({
-    instanceAvailability: "trial",
-    defaultAZ: "multi",
-    defaultProvider: "aws",
-    providers: ["aws"],
-  }),
-  onCreate: (_data, _onSuccess, onError) => onError("trial-unavailable"),
-} as CreateKafkaInstanceProps;
-
-ReachedMaxLimitForSupportedRegionAfterSubmitCreateForm.play = sampleSubmit;

--- a/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.tsx
+++ b/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.tsx
@@ -83,6 +83,7 @@ export const CreateKafkaInstance: FunctionComponent<
     regions,
     azOptions,
     availableProviders,
+    instanceAvailability,
 
     isNameTaken,
     isNameInvalid,
@@ -110,11 +111,6 @@ export const CreateKafkaInstance: FunctionComponent<
     onCreate,
   });
 
-  let { instanceAvailability } = useCreateKafkaInstanceMachine({
-    getAvailableProvidersAndDefaults,
-    onCreate,
-  });
-
   const onSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -123,11 +119,7 @@ export const CreateKafkaInstance: FunctionComponent<
     [create]
   );
 
-  const isRegionsAvailable =
-    regions && regions?.some(({ isDisabled }) => isDisabled !== true);
-
-  const disableControls =
-    isLoading || isSaving || !canCreate || !isRegionsAvailable;
+  const disableControls = isLoading || isSaving || !canCreate;
 
   const nameValidation = isNameError ? "error" : "default";
   const providerValidation = isProviderError ? "error" : "default";
@@ -135,8 +127,6 @@ export const CreateKafkaInstance: FunctionComponent<
   const azValidation = isAzError ? "error" : "default";
   const disableAZTooltip =
     azOptions === undefined || (azOptions?.multi === true && azOptions.single);
-
-  if (!isRegionsAvailable) instanceAvailability = "trial-unavailable";
 
   return (
     <Modal
@@ -154,7 +144,7 @@ export const CreateKafkaInstance: FunctionComponent<
           variant="primary"
           type="submit"
           form={FORM_ID}
-          isDisabled={!canSave || !isRegionsAvailable}
+          isDisabled={!canSave}
           spinnerAriaValueText={t("common:submitting_request")}
           isLoading={isSaving}
           data-testid="modalCreateKafka-buttonSubmit"
@@ -231,7 +221,7 @@ export const CreateKafkaInstance: FunctionComponent<
                 value={region}
                 regions={regions || []}
                 onChange={setRegion}
-                isDisabled={disableControls || !isRegionsAvailable}
+                isDisabled={disableControls}
                 validated={regionValidation}
               />
             </FormGroup>

--- a/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.tsx
+++ b/src/Kafka/CreateKafkaInstance/CreateKafkaInstance.tsx
@@ -83,7 +83,6 @@ export const CreateKafkaInstance: FunctionComponent<
     regions,
     azOptions,
     availableProviders,
-    instanceAvailability,
 
     isNameTaken,
     isNameInvalid,
@@ -111,6 +110,11 @@ export const CreateKafkaInstance: FunctionComponent<
     onCreate,
   });
 
+  let { instanceAvailability } = useCreateKafkaInstanceMachine({
+    getAvailableProvidersAndDefaults,
+    onCreate,
+  });
+
   const onSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -119,7 +123,11 @@ export const CreateKafkaInstance: FunctionComponent<
     [create]
   );
 
-  const disableControls = isLoading || isSaving || !canCreate;
+  const isRegionsAvailable =
+    regions && regions?.some(({ isDisabled }) => isDisabled !== true);
+
+  const disableControls =
+    isLoading || isSaving || !canCreate || !isRegionsAvailable;
 
   const nameValidation = isNameError ? "error" : "default";
   const providerValidation = isProviderError ? "error" : "default";
@@ -127,6 +135,8 @@ export const CreateKafkaInstance: FunctionComponent<
   const azValidation = isAzError ? "error" : "default";
   const disableAZTooltip =
     azOptions === undefined || (azOptions?.multi === true && azOptions.single);
+
+  if (!isRegionsAvailable) instanceAvailability = "trial-unavailable";
 
   return (
     <Modal
@@ -144,7 +154,7 @@ export const CreateKafkaInstance: FunctionComponent<
           variant="primary"
           type="submit"
           form={FORM_ID}
-          isDisabled={!canSave}
+          isDisabled={!canSave || !isRegionsAvailable}
           spinnerAriaValueText={t("common:submitting_request")}
           isLoading={isSaving}
           data-testid="modalCreateKafka-buttonSubmit"
@@ -221,7 +231,7 @@ export const CreateKafkaInstance: FunctionComponent<
                 value={region}
                 regions={regions || []}
                 onChange={setRegion}
-                isDisabled={disableControls || !(regions && regions.length > 0)}
+                isDisabled={disableControls || !isRegionsAvailable}
                 validated={regionValidation}
               />
             </FormGroup>

--- a/src/Kafka/CreateKafkaInstance/components/CloudRegionsSelect.tsx
+++ b/src/Kafka/CreateKafkaInstance/components/CloudRegionsSelect.tsx
@@ -39,9 +39,14 @@ export const CloudRegionSelect: FunctionComponent<CloudRegionProps> = ({
           key="placeholder"
           label={t("create-kafka-instance:select_region")}
         />,
-        (regions || []).map(({ id, displayName }, index) => {
+        (regions || []).map(({ id, displayName, isDisabled }, index) => {
           return (
-            <FormSelectOption key={index} value={id} label={displayName} />
+            <FormSelectOption
+              key={index}
+              value={id}
+              label={displayName}
+              isDisabled={isDisabled}
+            />
           );
         }),
       ]}

--- a/src/Kafka/CreateKafkaInstance/machines/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstance/machines/CreateKafkaInstanceMachine.ts
@@ -417,6 +417,9 @@ export function useCreateKafkaInstanceMachine({
 
   const isFormInvalid = state.context.creationError === "form-invalid";
   const isNameTaken = state.context.creationError === "name-taken";
+  const isRegionsAvailable = selectedProviderInfo?.regions?.some(
+    ({ isDisabled }) => isDisabled !== true
+  );
 
   return {
     name: state.context.name,
@@ -428,7 +431,9 @@ export function useCreateKafkaInstanceMachine({
     regions: selectedProviderInfo?.regions,
 
     availableProviders: state.context.availableProviders,
-    instanceAvailability: state.context.instanceAvailability,
+    instanceAvailability: !isRegionsAvailable
+      ? "trial-unavailable"
+      : state.context.instanceAvailability,
 
     isNameInvalid: state.hasTag(NAME_INVALID),
     isNameEmpty: state.hasTag(NAME_EMPTY),
@@ -449,8 +454,8 @@ export function useCreateKafkaInstanceMachine({
       ),
     isLoading: state.matches("loading"),
     isSaving: state.matches("saving"),
-    canCreate: state.matches("configuring"),
-    canSave: state.can("create"),
+    canCreate: isRegionsAvailable && state.matches("configuring"),
+    canSave: isRegionsAvailable && state.can("create"),
     isSystemUnavailable: state.hasTag(SYSTEM_UNAVAILABLE),
 
     error: state.context.creationError,

--- a/src/Kafka/CreateKafkaInstance/machines/types.ts
+++ b/src/Kafka/CreateKafkaInstance/machines/types.ts
@@ -9,6 +9,7 @@ export type Region = string;
 export type RegionInfo = {
   id: Region;
   displayName: string;
+  isDisabled?: boolean;
 };
 export type AZ = "single" | "multi";
 export type ProviderInfo = {


### PR DESCRIPTION
Implement feedback missed  on PR https://github.com/bf2fc6cc711aee1a0c2a/kas-ui/pull/1072/files#r817060682
Add below stories 
https://619e1921b3e38b003afeb2be-ryflrmybhy.chromatic.com/?path=/story/kafka-create-kafka-instance-create-kafka-instance--load-supported-regions-and-disabled-unsupported

https://619e1921b3e38b003afeb2be-ryflrmybhy.chromatic.com/?path=/story/kafka-create-kafka-instance-create-kafka-instance--reached-max-limit-for-trial-instance-for-supported-regions

![image](https://user-images.githubusercontent.com/11775081/157013780-dd650ec1-390b-42b6-8378-80adca9f93d6.png)

