### PR TITLE
chore: run jest with the --runInBand option to speed up tests on CI

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -30,8 +30,8 @@ jobs:
         id: cache-node-modules
         with:
           node-version: ${{ inputs.node-version }}
-      - run: npm run test -- --coverage
-      - run: npm run test-storybook:ci
+      - name: Run the test suite
+        run: npm run test-storybook:ci
       - name: Generate coverage report
         uses: codecov/codecov-action@v2
 

--- a/.github/workflows/storybook-to-pages.yml
+++ b/.github/workflows/storybook-to-pages.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           npm ci
           npm run test:generate-output
-          npm run build-storybook -- --quiet --loglevel silent
+          npm run build-storybook
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.5

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "prebuild-storybook": "npm run test:generate-output",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook --quiet --loglevel silent",
     "prebuild": "npm run parse-i18n",
     "build": "rollup -c",
     "chromatic": "chromatic",
@@ -31,9 +31,9 @@
     "prepare": "npm run clean && npm run package && husky install",
     "storybook": "start-storybook -p 6006",
     "test-storybook": "test-storybook",
-    "test-storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run build-storybook --quiet && npx http-server storybook-static --port 6006 --silent\" \"wait-on tcp:6006 && npm run test-storybook\"",
-    "test": "jest",
-    "test:generate-output": "jest --json --outputFile=.jest-test-results.json",
+    "test-storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run build-storybook && npx http-server storybook-static --port 6006 --silent\" \"wait-on tcp:6006 && npm run test-storybook\"",
+    "test": "jest --runInBand",
+    "test:generate-output": "npm run test -- --json --outputFile=.jest-test-results.json",
     "test:watch": "npm run test -- --watch"
   },
   "repository": {


### PR DESCRIPTION
This will run tests sequentially, but will make babel run just once instead of many times in parallel. It should improve the overall runtime especially on CI