### PR TITLE
Adding header to the table in Kafka overview page

### DIFF
--- a/locales/en/kafkaoverview-v2.json
+++ b/locales/en/kafkaoverview-v2.json
@@ -1,4 +1,5 @@
 {
+  "awsWebServiceTitle": "Amazon Web Services",
   "cloudProvidersTitle": "Cloud providers",
   "contactSalesCardCallToActionButton": "Contact sales",
   "contactSalesCardMainText": "Contact sales to get a pre-paid subscription or modify limits of your current subscription.",
@@ -15,14 +16,13 @@
   "kafkaInstanceCapacityfooter2": "to discuss your options. You can check your current storage usage by",
   "kafkaInstanceCapacityTitle": "Kafka instance capacity",
   "microsoftAzureDescription": "Coming soon",
+  "microsoftAzureTitle": "Microsoft Azure",
   "pricingModalTitle": "Pricing model",
   "purchaseCardCallToActionButton": "Purchase now",
   "purchaseCardMainText": "In the United States or Canada, purchase a pay-as-you-go subscription for up to 25 streaming units through Red Hat Marketplace.",
   "purchaseCardTitle": "Purchase now",
-  "secondStreamingUnit": "2 streaming unit",
+  "secondStreamingUnit": "2 streaming units",
   "steamingUnit": "Streaming unit",
   "storage": "Storage",
-  "streamingUnitText": "A <strong>{{value}}</strong> determines the default maximum capacity of a Kafka instance. The more streaming units your Kafka instance has, the larger its capacity will be.",
-  "awsWebServiceTitle": "Amazon Web Services",
-  "microsoftAzureTitle": "Microsoft Azure"
+  "streamingUnitText": "A <strong>{{value}}</strong> determines the default maximum capacity of a Kafka instance. The more streaming units your Kafka instance has, the larger its capacity will be."
 }

--- a/src/AppServices/KafkaPage/__snapshots__/KafkaPageV2.test.tsx.snap
+++ b/src/AppServices/KafkaPage/__snapshots__/KafkaPageV2.test.tsx.snap
@@ -371,10 +371,16 @@ exports[`KafkaPage renders 1`] = `
                     />
                     <th
                       class=""
-                    />
+                      scope="col"
+                    >
+                      1 streaming unit
+                    </th>
                     <th
                       class=""
-                    />
+                      scope="col"
+                    >
+                      2 streaming units
+                    </th>
                   </tr>
                 </thead>
                 <tbody
@@ -395,13 +401,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 50
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 100
                     </td>
@@ -420,13 +426,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 100
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 200
                     </td>
@@ -445,13 +451,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 1000
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 2000
                     </td>
@@ -470,13 +476,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 1500
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 3000
                     </td>
@@ -495,13 +501,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 3000
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 6000
                     </td>
@@ -520,13 +526,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 100
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 200
                     </td>
@@ -545,13 +551,13 @@ exports[`KafkaPage renders 1`] = `
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="1 streaming unit"
                     >
                       up to 1
                     </td>
                     <td
                       class=""
-                      data-label=""
+                      data-label="2 streaming units"
                     >
                       up to 1
                     </td>

--- a/src/AppServices/KafkaPage/component/KafkaInstanceCapacityTable.tsx
+++ b/src/AppServices/KafkaPage/component/KafkaInstanceCapacityTable.tsx
@@ -16,7 +16,7 @@ interface CapacityTable {
 }
 
 export const KafkaInstanceCapacityTable: FunctionComponent = () => {
-  const { t } = useTranslation("kafkaoverview");
+  const { t } = useTranslation("kafkaoverview-v2");
 
   const capacityTable: CapacityTable[] = [
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding header to the table in Kafka overview page


**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`


