### PR TITLE
feat: Add partition limit message to the topic partitions card

### DIFF
--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -53,5 +53,12 @@
   "total_bytes": "Bytes incoming and outgoing",
   "total_bytes_popover_header": "Bytes incoming and outgoing",
   "used_disk_space": "Used disk space",
-  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed."
+  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
+  "partition_limit": "Limit 1000 partitions.",
+  "partition_limit_approaching_description_1": "This Kafka Instance is approaching the partition limit. If the Kafka Instance exceeds 1000 partitions, it might experience degraded performance.",
+  "partition_limit_approaching_description_2": "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances.",
+  "partition_limit_reached_description_1": "This Kafka Instance has reached its maximum partition limit and might experience degraded performance.",
+  "partition_limit_reached_description_2": "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances.",
+  "partition_limit_approaching_title": "This Kafka Instance is close to reaching the partition limit",
+  "partition_limit_reached_title": "This Kafka Instance reached the partition limit"
 }

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -37,6 +37,13 @@
   "metric_not_available": "Data unavailable",
   "outgoing_bytes": "Outgoing bytes ({{topic}})",
   "outgoing_bytes_all_topics": "Outgoing bytes (all topics)",
+  "partition_limit": "Limit {{topic}} partitions.",
+  "partition_limit_approaching_description_1": "This Kafka instance is approaching the partition limit. If the Kafka instance exceeds {{limit}} partitions, it might experience degraded performance.",
+  "partition_limit_approaching_description_2": "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances.",
+  "partition_limit_approaching_title": "This Kafka instance is close to reaching the partition limit",
+  "partition_limit_reached_description_1": "This Kafka instance has reached its maximum partition limit and might experience degraded performance.",
+  "partition_limit_reached_description_2": "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances.",
+  "partition_limit_reached_title": "This Kafka instance reached the partition limit",
   "refreshing": "Getting data",
   "topic_incoming_message_rate": "Incoming message rate",
   "topic_incoming_message_rate_help_text": "Incoming message rate is the number of messages per second received by one or more topics in the $t(common:kafka) instance over time. This metric enables you to verify that messages are produced to topics and that producers are functioning properly. To modify the incoming messages per topic, you can adjust the corresponding producer as needed.",
@@ -53,12 +60,5 @@
   "total_bytes": "Bytes incoming and outgoing",
   "total_bytes_popover_header": "Bytes incoming and outgoing",
   "used_disk_space": "Used disk space",
-  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
-  "partition_limit": "Limit 1000 partitions.",
-  "partition_limit_approaching_description_1": "This Kafka Instance is approaching the partition limit. If the Kafka Instance exceeds 1000 partitions, it might experience degraded performance.",
-  "partition_limit_approaching_description_2": "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances.",
-  "partition_limit_reached_description_1": "This Kafka Instance has reached its maximum partition limit and might experience degraded performance.",
-  "partition_limit_reached_description_2": "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances.",
-  "partition_limit_approaching_title": "This Kafka Instance is close to reaching the partition limit",
-  "partition_limit_reached_title": "This Kafka Instance reached the partition limit"
+  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed."
 }

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -60,5 +60,7 @@
   "total_bytes": "Bytes incoming and outgoing",
   "total_bytes_popover_header": "Bytes incoming and outgoing",
   "used_disk_space": "Used disk space",
-  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed."
+  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
+  "metrics_lag_title": "Metrics experience lag",
+  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages."
 }

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -37,7 +37,7 @@
   "metric_not_available": "Data unavailable",
   "outgoing_bytes": "Outgoing bytes ({{topic}})",
   "outgoing_bytes_all_topics": "Outgoing bytes (all topics)",
-  "partition_limit": "Limit {{topic}} partitions.",
+  "partition_limit": "Limit {{topic}} partitions",
   "partition_limit_approaching_description_1": "This Kafka instance is approaching the partition limit. If the Kafka instance exceeds {{limit}} partitions, it might experience degraded performance.",
   "partition_limit_approaching_description_2": "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances.",
   "partition_limit_approaching_title": "This Kafka instance is close to reaching the partition limit",

--- a/src/Kafka/Metrics/Metrics.stories.tsx
+++ b/src/Kafka/Metrics/Metrics.stories.tsx
@@ -353,8 +353,8 @@ Sample data that show the charts with data over the limits.
   },
 };
 
-export const TopicPartitionCardNearToLimit = Template.bind({});
-TopicPartitionCardNearToLimit.args = {
+export const LimitsNearing = Template.bind({});
+LimitsNearing.args = {
   getMetricsKpi: () =>
     fakeApi({
       topics: 1,
@@ -366,17 +366,6 @@ TopicPartitionCardNearToLimit.args = {
     getKafkaInstanceMetrics({ ...props, offset: 3 }),
   getTopicsMetrics: (props) =>
     getTopicsMetricsOneTopic({ ...props, offset: 3 }),
-};
-TopicPartitionCardNearToLimit.storyName =
-  "Topics Partition count near to the limit";
-TopicPartitionCardNearToLimit.parameters = {
-  docs: {
-    description: {
-      story: `
-When the Topics partition count is near to the limit
-      `,
-    },
-  },
 };
 
 // TODO: story disabled since testing this in Storybook is too flaky. We should write a unit test for this instead

--- a/src/Kafka/Metrics/Metrics.stories.tsx
+++ b/src/Kafka/Metrics/Metrics.stories.tsx
@@ -166,7 +166,12 @@ empty state is shown inside each KPI card.
 export const NoTopics = Template.bind({});
 NoTopics.args = {
   getMetricsKpi: () =>
-    fakeApi({ topics: 0, topicPartitions: 0, consumerGroups: 0 }),
+    fakeApi({
+      topics: 0,
+      topicPartitions: 0,
+      consumerGroups: 0,
+      topicPartitionsLimit: 1000,
+    }),
   getKafkaInstanceMetrics,
   getTopicsMetrics: () =>
     fakeApi({
@@ -196,7 +201,12 @@ The toolbar is disabled, but the refresh button can be clicked.
 export const TopicsJustCreated = Template.bind({});
 TopicsJustCreated.args = {
   getMetricsKpi: () =>
-    fakeApi({ topics: 1, topicPartitions: 3, consumerGroups: 0 }),
+    fakeApi({
+      topics: 1,
+      topicPartitions: 3,
+      consumerGroups: 0,
+      topicPartitionsLimit: 1000,
+    }),
   getKafkaInstanceMetrics,
   getTopicsMetrics: () =>
     fakeApi({
@@ -226,7 +236,12 @@ The toolbar is disabled, but the refresh button can be clicked.
 export const TopicsRecentlyCreated = Template.bind({});
 TopicsRecentlyCreated.args = {
   getMetricsKpi: () =>
-    fakeApi({ topics: 1, topicPartitions: 6, consumerGroups: 0 }),
+    fakeApi({
+      topics: 1,
+      topicPartitions: 6,
+      consumerGroups: 0,
+      topicPartitionsLimit: 1000,
+    }),
   getKafkaInstanceMetrics: (props) =>
     getKafkaInstanceMetrics({ ...props, offset: 3 }),
   getTopicsMetrics: (props) =>
@@ -310,7 +325,12 @@ _Data unavailable_ empty state is shown in place of the charts with missing
 export const LimitsReached = Template.bind({});
 LimitsReached.args = {
   getMetricsKpi: () =>
-    fakeApi({ topics: 1, topicPartitions: 1000, consumerGroups: 0 }),
+    fakeApi({
+      topics: 1,
+      topicPartitions: 950,
+      consumerGroups: 0,
+      topicPartitionsLimit: 1000,
+    }),
   getKafkaInstanceMetrics: ({ duration }) =>
     fakeApi({
       usedDiskSpaceMetrics: makeMetrics(duration, 900, 1100, 10 ** 9),

--- a/src/Kafka/Metrics/Metrics.stories.tsx
+++ b/src/Kafka/Metrics/Metrics.stories.tsx
@@ -226,7 +226,7 @@ The toolbar is disabled, but the refresh button can be clicked.
 export const TopicsRecentlyCreated = Template.bind({});
 TopicsRecentlyCreated.args = {
   getMetricsKpi: () =>
-    fakeApi({ topics: 1, topicPartitions: 3, consumerGroups: 0 }),
+    fakeApi({ topics: 1, topicPartitions: 6, consumerGroups: 0 }),
   getKafkaInstanceMetrics: (props) =>
     getKafkaInstanceMetrics({ ...props, offset: 3 }),
   getTopicsMetrics: (props) =>
@@ -309,7 +309,8 @@ _Data unavailable_ empty state is shown in place of the charts with missing
 
 export const LimitsReached = Template.bind({});
 LimitsReached.args = {
-  getMetricsKpi,
+  getMetricsKpi: () =>
+    fakeApi({ topics: 1, topicPartitions: 1000, consumerGroups: 0 }),
   getKafkaInstanceMetrics: ({ duration }) =>
     fakeApi({
       usedDiskSpaceMetrics: makeMetrics(duration, 900, 1100, 10 ** 9),

--- a/src/Kafka/Metrics/Metrics.stories.tsx
+++ b/src/Kafka/Metrics/Metrics.stories.tsx
@@ -327,7 +327,7 @@ LimitsReached.args = {
   getMetricsKpi: () =>
     fakeApi({
       topics: 1,
-      topicPartitions: 950,
+      topicPartitions: 1001,
       consumerGroups: 0,
       topicPartitionsLimit: 1000,
     }),
@@ -348,6 +348,32 @@ LimitsReached.parameters = {
     description: {
       story: `
 Sample data that show the charts with data over the limits.
+      `,
+    },
+  },
+};
+
+export const TopicPartitionCardNearToLimit = Template.bind({});
+TopicPartitionCardNearToLimit.args = {
+  getMetricsKpi: () =>
+    fakeApi({
+      topics: 1,
+      topicPartitions: 960,
+      consumerGroups: 0,
+      topicPartitionsLimit: 1000,
+    }),
+  getKafkaInstanceMetrics: (props) =>
+    getKafkaInstanceMetrics({ ...props, offset: 3 }),
+  getTopicsMetrics: (props) =>
+    getTopicsMetricsOneTopic({ ...props, offset: 3 }),
+};
+TopicPartitionCardNearToLimit.storyName =
+  "Topics Partition count near to the limit";
+TopicPartitionCardNearToLimit.parameters = {
+  docs: {
+    description: {
+      story: `
+When the Topics partition count is near to the limit
       `,
     },
   },

--- a/src/Kafka/Metrics/Metrics.test.tsx
+++ b/src/Kafka/Metrics/Metrics.test.tsx
@@ -30,6 +30,7 @@ describe("Metrics", () => {
 
     const partitionsKpi = within(await comp.findByTestId("Topic partitions"));
     expect(await partitionsKpi.findByText("6")).toBeInTheDocument();
+    expect(await comp.findByText("Limit 1000 partitions")).toBeInTheDocument();
 
     const consumerGroups = within(await comp.findByTestId("Consumer groups"));
     expect(await consumerGroups.findByText("12")).toBeInTheDocument();

--- a/src/Kafka/Metrics/Metrics.tsx
+++ b/src/Kafka/Metrics/Metrics.tsx
@@ -30,6 +30,7 @@ import { MetricsLagAlert } from "./components/MetricsLagAlert";
 export type MetricsProps = {
   onCreateTopic: () => void;
   onClickClose: () => void;
+  isClosed: boolean;
 } & KafkaInstanceMetricsProviderProps &
   TopicsMetricsProviderProps &
   MetricsKpiProviderProps;
@@ -40,6 +41,7 @@ export const Metrics: VoidFunctionComponent<MetricsProps> = ({
   getMetricsKpi,
   onCreateTopic,
   onClickClose,
+  isClosed,
 }) => {
   return (
     <TopicsMetricsProvider getTopicsMetrics={getTopicsMetrics}>
@@ -50,6 +52,7 @@ export const Metrics: VoidFunctionComponent<MetricsProps> = ({
           <ConnectedMetrics
             onCreateTopic={onCreateTopic}
             onClickClose={onClickClose}
+            isClosed={isClosed}
           />
         </MetricsKpiProvider>
       </KafkaInstanceMetricsProvider>
@@ -60,10 +63,12 @@ export const Metrics: VoidFunctionComponent<MetricsProps> = ({
 type ConnectedMetricsProps = {
   onCreateTopic: () => void;
   onClickClose: () => void;
+  isClosed: boolean;
 };
 const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
   onCreateTopic,
   onClickClose,
+  isClosed,
 }) => {
   const { t } = useTranslation();
   const kafkaInstanceMetrics = useKafkaInstanceMetrics();
@@ -86,7 +91,7 @@ const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
       return (
         <Stack hasGutter>
           <StackItem>
-            <MetricsLagAlert onClickClose={onClickClose} />
+            <MetricsLagAlert onClickClose={onClickClose} isClosed={isClosed} />
           </StackItem>
           <StackItem>
             <MetricsLayout

--- a/src/Kafka/Metrics/Metrics.tsx
+++ b/src/Kafka/Metrics/Metrics.tsx
@@ -23,6 +23,7 @@ import {
 import { useKafkaInstanceMetrics } from "./useKafkaInstanceMetrics";
 import { useMetricsKpi } from "./useMetricsKpi";
 import { useTopicsMetrics } from "./useTopicsMetrics";
+import { PartitionCard } from "./components/PartitionCard";
 
 export type MetricsProps = {
   onCreateTopic: () => void;
@@ -84,11 +85,9 @@ const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
             />
           }
           topicPartitionsKpi={
-            <CardKpi
+            <PartitionCard
               metric={metricsKpi.topicPartitions}
               isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
-              name={t("metrics:metric_kpi_topicPartitions_name")}
-              popover={t("metrics:metric_kpi_topicPartitions_description")}
             />
           }
           consumerGroupKpi={

--- a/src/Kafka/Metrics/Metrics.tsx
+++ b/src/Kafka/Metrics/Metrics.tsx
@@ -24,9 +24,12 @@ import { useKafkaInstanceMetrics } from "./useKafkaInstanceMetrics";
 import { useMetricsKpi } from "./useMetricsKpi";
 import { useTopicsMetrics } from "./useTopicsMetrics";
 import { PartitionCard } from "./components/PartitionCard";
+import { Stack, StackItem } from "@patternfly/react-core";
+import { MetricsLagAlert } from "./components/MetricsLagAlert";
 
 export type MetricsProps = {
   onCreateTopic: () => void;
+  onClickClose: () => void;
 } & KafkaInstanceMetricsProviderProps &
   TopicsMetricsProviderProps &
   MetricsKpiProviderProps;
@@ -36,6 +39,7 @@ export const Metrics: VoidFunctionComponent<MetricsProps> = ({
   getTopicsMetrics,
   getMetricsKpi,
   onCreateTopic,
+  onClickClose,
 }) => {
   return (
     <TopicsMetricsProvider getTopicsMetrics={getTopicsMetrics}>
@@ -43,7 +47,10 @@ export const Metrics: VoidFunctionComponent<MetricsProps> = ({
         getKafkaInstanceMetrics={getKafkaInstanceMetrics}
       >
         <MetricsKpiProvider getMetricsKpi={getMetricsKpi}>
-          <ConnectedMetrics onCreateTopic={onCreateTopic} />
+          <ConnectedMetrics
+            onCreateTopic={onCreateTopic}
+            onClickClose={onClickClose}
+          />
         </MetricsKpiProvider>
       </KafkaInstanceMetricsProvider>
     </TopicsMetricsProvider>
@@ -52,9 +59,11 @@ export const Metrics: VoidFunctionComponent<MetricsProps> = ({
 
 type ConnectedMetricsProps = {
   onCreateTopic: () => void;
+  onClickClose: () => void;
 };
 const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
   onCreateTopic,
+  onClickClose,
 }) => {
   const { t } = useTranslation();
   const kafkaInstanceMetrics = useKafkaInstanceMetrics();
@@ -75,35 +84,48 @@ const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
       return <EmptyStateMetricsUnavailable />;
     default:
       return (
-        <MetricsLayout
-          topicsKpi={
-            <CardKpi
-              metric={metricsKpi.topics}
-              isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
-              name={t("metrics:metric_kpi_topics_name")}
-              popover={t("metrics:metric_kpi_topics_description")}
+        <Stack hasGutter>
+          <StackItem>
+            <MetricsLagAlert onClickClose={onClickClose} />
+          </StackItem>
+          <StackItem>
+            <MetricsLayout
+              topicsKpi={
+                <CardKpi
+                  metric={metricsKpi.topics}
+                  isLoading={
+                    metricsKpi.isInitialLoading || metricsKpi.isLoading
+                  }
+                  name={t("metrics:metric_kpi_topics_name")}
+                  popover={t("metrics:metric_kpi_topics_description")}
+                />
+              }
+              topicPartitionsKpi={
+                <PartitionCard
+                  metric={metricsKpi.topicPartitions}
+                  isLoading={
+                    metricsKpi.isInitialLoading || metricsKpi.isLoading
+                  }
+                  topicPartitionsLimit={metricsKpi.topicPartitionsLimit}
+                />
+              }
+              consumerGroupKpi={
+                <CardKpi
+                  metric={metricsKpi.consumerGroups}
+                  isLoading={
+                    metricsKpi.isInitialLoading || metricsKpi.isLoading
+                  }
+                  name={t("metrics:metric_kpi_consumerGroup_name")}
+                  popover={t("metrics:metric_kpi_consumerGroup_description")}
+                />
+              }
+              diskSpaceMetrics={<ConnectedKafkaInstanceMetrics />}
+              topicMetrics={
+                <ConnectedTopicsMetrics onCreateTopic={onCreateTopic} />
+              }
             />
-          }
-          topicPartitionsKpi={
-            <PartitionCard
-              metric={metricsKpi.topicPartitions}
-              isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
-              topicPartitionsLimit={metricsKpi.topicPartitionsLimit}
-            />
-          }
-          consumerGroupKpi={
-            <CardKpi
-              metric={metricsKpi.consumerGroups}
-              isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
-              name={t("metrics:metric_kpi_consumerGroup_name")}
-              popover={t("metrics:metric_kpi_consumerGroup_description")}
-            />
-          }
-          diskSpaceMetrics={<ConnectedKafkaInstanceMetrics />}
-          topicMetrics={
-            <ConnectedTopicsMetrics onCreateTopic={onCreateTopic} />
-          }
-        />
+          </StackItem>
+        </Stack>
       );
   }
 };

--- a/src/Kafka/Metrics/Metrics.tsx
+++ b/src/Kafka/Metrics/Metrics.tsx
@@ -88,6 +88,7 @@ const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
             <PartitionCard
               metric={metricsKpi.topicPartitions}
               isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
+              topicPartitionsLimit={metricsKpi.topicPartitionsLimit}
             />
           }
           consumerGroupKpi={

--- a/src/Kafka/Metrics/components/CardKpi.tsx
+++ b/src/Kafka/Metrics/components/CardKpi.tsx
@@ -29,21 +29,21 @@ export const CardKpi: VoidFunctionComponent<CardKpiProps> = ({
         {name} <ChartPopover title={name} description={popover} />
       </CardTitle>
       <CardBody>
-        <Bullseye>
-          {!isLoading &&
-            (metric === undefined ? (
+        {!isLoading &&
+          (metric === undefined ? (
+            <Bullseye>
               <EmptyStateNoMetricsData />
-            ) : (
-              <Title
-                headingLevel="h3"
-                size="4xl"
-                aria-valuetext={`${metric} ${name}`}
-              >
-                {metric}
-              </Title>
-            ))}
-          {isLoading && <Skeleton width="50px" shape="square" />}
-        </Bullseye>
+            </Bullseye>
+          ) : (
+            <Title
+              headingLevel="h3"
+              size="4xl"
+              aria-valuetext={`${metric} ${name}`}
+            >
+              {metric}
+            </Title>
+          ))}
+        {isLoading && <Skeleton width="50px" shape="square" />}
       </CardBody>
     </Card>
   );

--- a/src/Kafka/Metrics/components/MetricsLagAlert.stories.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { MetricsLagAlert } from "./MetricsLagAlert";
+
+export default {
+  component: MetricsLagAlert,
+  args: {},
+} as ComponentMeta<typeof MetricsLagAlert>;
+
+const Template: ComponentStory<typeof MetricsLagAlert> = (args) => (
+  <MetricsLagAlert {...args} />
+);
+
+export const LagMessage = Template.bind({});

--- a/src/Kafka/Metrics/components/MetricsLagAlert.stories.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { useState } from "react";
 import { MetricsLagAlert } from "./MetricsLagAlert";
 
 export default {
@@ -6,8 +7,14 @@ export default {
   args: {},
 } as ComponentMeta<typeof MetricsLagAlert>;
 
-const Template: ComponentStory<typeof MetricsLagAlert> = (args) => (
-  <MetricsLagAlert {...args} />
-);
+const Template: ComponentStory<typeof MetricsLagAlert> = () => {
+  const [isClosed, setIsClosed] = useState<boolean>(false);
+
+  const onClickClose = () => {
+    setIsClosed(!isClosed);
+  };
+
+  return <MetricsLagAlert isClosed={isClosed} onClickClose={onClickClose} />;
+};
 
 export const LagMessage = Template.bind({});

--- a/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
@@ -1,0 +1,24 @@
+import { render, waitForI18n } from "../../../test-utils";
+import { composeStories } from "@storybook/testing-react";
+import * as stories from "./MetricsLagAlert.stories";
+import { userEvent } from "@storybook/testing-library";
+
+const { LagMessage } = composeStories(stories);
+
+describe("Metric lag", () => {
+  it("Metric lag alert message", async () => {
+    const onClickClose = jest.fn();
+    const comp = render(<LagMessage onClickClose={onClickClose} />);
+    await waitForI18n(comp);
+
+    expect(await comp.findByText("Metrics experience lag")).toBeInTheDocument();
+    expect(
+      await comp.findByText(
+        "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages."
+      )
+    ).toBeInTheDocument();
+
+    userEvent.click(await comp.getByRole("button"));
+    expect(onClickClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
@@ -7,8 +7,7 @@ const { LagMessage } = composeStories(stories);
 
 describe("Metric lag", () => {
   it("Metric lag alert message", async () => {
-    const onClickClose = jest.fn();
-    const comp = render(<LagMessage onClickClose={onClickClose} />);
+    const comp = render(<LagMessage />);
     await waitForI18n(comp);
 
     expect(await comp.findByText("Metrics experience lag")).toBeInTheDocument();
@@ -19,6 +18,14 @@ describe("Metric lag", () => {
     ).toBeInTheDocument();
 
     userEvent.click(await comp.getByRole("button"));
-    expect(onClickClose).toHaveBeenCalledTimes(1);
+
+    expect(
+      await comp.queryByText("Metrics experience lag")
+    ).not.toBeInTheDocument();
+    expect(
+      await comp.queryByText(
+        "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages."
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/Kafka/Metrics/components/MetricsLagAlert.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.tsx
@@ -1,0 +1,25 @@
+import { VoidFunctionComponent } from "react";
+import { Alert, AlertActionCloseButton, Card } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+export type MetricsLagAlertProps = {
+  onClickClose: () => void;
+};
+
+export const MetricsLagAlert: VoidFunctionComponent<MetricsLagAlertProps> = ({
+  onClickClose,
+}) => {
+  const { t } = useTranslation("metrics");
+  return (
+    <Card>
+      <Alert
+        isInline
+        variant="info"
+        title={t("metrics_lag_title")}
+        actionClose={<AlertActionCloseButton onClose={onClickClose} />}
+      >
+        <p>{t("metrics_lag_description")}</p>
+      </Alert>
+    </Card>
+  );
+};

--- a/src/Kafka/Metrics/components/MetricsLagAlert.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.tsx
@@ -3,23 +3,30 @@ import { Alert, AlertActionCloseButton, Card } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 
 export type MetricsLagAlertProps = {
+  isClosed: boolean;
   onClickClose: () => void;
 };
 
 export const MetricsLagAlert: VoidFunctionComponent<MetricsLagAlertProps> = ({
+  isClosed,
   onClickClose,
 }) => {
   const { t } = useTranslation("metrics");
-  return (
-    <Card>
-      <Alert
-        isInline
-        variant="info"
-        title={t("metrics_lag_title")}
-        actionClose={<AlertActionCloseButton onClose={onClickClose} />}
-      >
-        <p>{t("metrics_lag_description")}</p>
-      </Alert>
-    </Card>
-  );
+
+  if (!isClosed) {
+    return (
+      <Card>
+        <Alert
+          isInline
+          variant="info"
+          title={t("metrics_lag_title")}
+          actionClose={<AlertActionCloseButton onClose={onClickClose} />}
+        >
+          <p>{t("metrics_lag_description")}</p>
+        </Alert>
+      </Card>
+    );
+  } else {
+    return <> </>;
+  }
 };

--- a/src/Kafka/Metrics/components/PartitionCard.stories.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.stories.tsx
@@ -4,8 +4,8 @@ import { PartitionCard } from "./PartitionCard";
 export default {
   component: PartitionCard,
   args: {
-    metric: 100,
     isLoading: false,
+    topicPartitionsLimit: 1000,
   },
 } as ComponentMeta<typeof PartitionCard>;
 
@@ -14,7 +14,12 @@ const Template: ComponentStory<typeof PartitionCard> = (args) => (
 );
 
 export const TopicPartitionCard = Template.bind({});
-TopicPartitionCard.args = {};
+TopicPartitionCard.args = {
+  metric: 100,
+};
+
+export const TopicPartitionUndefined = Template.bind({});
+TopicPartitionUndefined.args = {};
 
 export const TopicPartitionsLimitReached = Template.bind({});
 TopicPartitionsLimitReached.args = {

--- a/src/Kafka/Metrics/components/PartitionCard.stories.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { PartitionCard } from "./PartitionCard";
+
+export default {
+  component: PartitionCard,
+  args: {
+    metric: 100,
+    isLoading: false,
+  },
+} as ComponentMeta<typeof PartitionCard>;
+
+const Template: ComponentStory<typeof PartitionCard> = (args) => (
+  <PartitionCard {...args} />
+);
+
+export const TopicPartitionCard = Template.bind({});
+TopicPartitionCard.args = {};
+
+export const TopicPartitionsLimitReached = Template.bind({});
+TopicPartitionsLimitReached.args = {
+  metric: 1000,
+};
+
+export const TopicPartitionsLimitApproaching = Template.bind({});
+TopicPartitionsLimitApproaching.args = {
+  metric: 960,
+};

--- a/src/Kafka/Metrics/components/PartitionCard.test.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, waitForI18n, within } from "../../../test-utils";
+import { composeStories } from "@storybook/testing-react";
+import * as stories from "./PartitionCard.stories";
+import { fireEvent, userEvent } from "@storybook/testing-library";
+
+const { TopicPartitionsLimitApproaching, TopicPartitionsLimitReached } =
+  composeStories(stories);
+
+describe("Topic partition", () => {
+  it("Topic partition when limit is approaching", async () => {
+    const comp = render(<TopicPartitionsLimitApproaching />);
+    await waitForI18n(comp);
+
+    expect(
+      await comp.findByText(
+        "This Kafka Instance is close to reaching the partition limit"
+      )
+    ).toBeInTheDocument();
+    userEvent.click(
+      await comp.getByRole("button", { name: "Warning alert details" })
+    );
+
+    expect(
+      await comp.findByText(
+        "This Kafka Instance is approaching the partition limit. If the Kafka Instance exceeds 1000 partitions, it might experience degraded performance."
+      )
+    ).toBeInTheDocument();
+    expect(
+      await comp.findByText(
+        "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("Topic partition when limit is approaching", async () => {
+    const comp = render(<TopicPartitionsLimitReached />);
+    await waitForI18n(comp);
+
+    expect(
+      await comp.findByText("This Kafka Instance reached the partition limit")
+    ).toBeInTheDocument();
+    userEvent.click(
+      await comp.getByRole("button", { name: "Danger alert details" })
+    );
+
+    expect(
+      await comp.findByText(
+        "This Kafka Instance has reached its maximum partition limit and might experience degraded performance."
+      )
+    ).toBeInTheDocument();
+    expect(
+      await comp.findByText(
+        "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/Kafka/Metrics/components/PartitionCard.test.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.test.tsx
@@ -1,10 +1,13 @@
-import { render, waitForI18n, within } from "../../../test-utils";
+import { render, waitForI18n } from "../../../test-utils";
 import { composeStories } from "@storybook/testing-react";
 import * as stories from "./PartitionCard.stories";
-import { fireEvent, userEvent } from "@storybook/testing-library";
+import { userEvent } from "@storybook/testing-library";
 
-const { TopicPartitionsLimitApproaching, TopicPartitionsLimitReached } =
-  composeStories(stories);
+const {
+  TopicPartitionsLimitApproaching,
+  TopicPartitionsLimitReached,
+  TopicPartitionUndefined,
+} = composeStories(stories);
 
 describe("Topic partition", () => {
   it("Topic partition when limit is approaching", async () => {
@@ -53,5 +56,12 @@ describe("Topic partition", () => {
         "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances."
       )
     ).toBeInTheDocument();
+  });
+
+  it("Topic partition is undefined", async () => {
+    const comp = render(<TopicPartitionUndefined />);
+    await waitForI18n(comp);
+
+    expect(await comp.findByText("Data unavailable")).toBeInTheDocument();
   });
 });

--- a/src/Kafka/Metrics/components/PartitionCard.test.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.test.tsx
@@ -13,7 +13,7 @@ describe("Topic partition", () => {
 
     expect(
       await comp.findByText(
-        "This Kafka Instance is close to reaching the partition limit"
+        "This Kafka instance is close to reaching the partition limit"
       )
     ).toBeInTheDocument();
     userEvent.click(
@@ -22,12 +22,12 @@ describe("Topic partition", () => {
 
     expect(
       await comp.findByText(
-        "This Kafka Instance is approaching the partition limit. If the Kafka Instance exceeds 1000 partitions, it might experience degraded performance."
+        "This Kafka instance is approaching the partition limit. If the Kafka instance exceeds 1000 partitions, it might experience degraded performance."
       )
     ).toBeInTheDocument();
     expect(
       await comp.findByText(
-        "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances."
+        "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances."
       )
     ).toBeInTheDocument();
   });
@@ -37,7 +37,7 @@ describe("Topic partition", () => {
     await waitForI18n(comp);
 
     expect(
-      await comp.findByText("This Kafka Instance reached the partition limit")
+      await comp.findByText("This Kafka instance reached the partition limit")
     ).toBeInTheDocument();
     userEvent.click(
       await comp.getByRole("button", { name: "Danger alert details" })
@@ -45,12 +45,12 @@ describe("Topic partition", () => {
 
     expect(
       await comp.findByText(
-        "This Kafka Instance has reached its maximum partition limit and might experience degraded performance."
+        "This Kafka instance has reached its maximum partition limit and might experience degraded performance."
       )
     ).toBeInTheDocument();
     expect(
       await comp.findByText(
-        "To create more partitions, consider migrating to a larger Kafka Instance or splitting your workloads across multiple instances."
+        "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances."
       )
     ).toBeInTheDocument();
   });

--- a/src/Kafka/Metrics/components/PartitionCard.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.tsx
@@ -62,7 +62,7 @@ export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
               >
                 {metric}{" "}
                 {(() => {
-                  if (metric === topicPartitionsLimit) {
+                  if (metric >= topicPartitionsLimit) {
                     return (
                       <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
                     );
@@ -87,7 +87,7 @@ export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
         {isLoading && <Skeleton width="50px" shape="square" />}
       </CardBody>
       {(() => {
-        if (metric && metric === topicPartitionsLimit) {
+        if (metric && metric >= topicPartitionsLimit) {
           return (
             <CardFooter>
               <Alert

--- a/src/Kafka/Metrics/components/PartitionCard.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.tsx
@@ -9,8 +9,6 @@ import {
   Text,
   CardFooter,
   Alert,
-  Stack,
-  StackItem,
   AlertVariant,
 } from "@patternfly/react-core";
 import {
@@ -23,13 +21,15 @@ import { ChartPopover } from "./ChartPopover";
 import { EmptyStateNoMetricsData } from "./EmptyStateNoMetricsData";
 
 type PartitionCardProps = {
-  metric: string | number | undefined;
+  metric: number | undefined;
   isLoading: boolean;
+  topicPartitionsLimit: number | undefined;
 };
 
 export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
   metric,
   isLoading,
+  topicPartitionsLimit = 0,
 }) => {
   const { t } = useTranslation();
 
@@ -46,48 +46,48 @@ export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
         />
       </CardTitle>
       <CardBody>
-        <Bullseye>
-          {!isLoading &&
-            (metric === undefined ? (
+        {!isLoading &&
+          (metric === undefined ? (
+            <Bullseye>
               <EmptyStateNoMetricsData />
-            ) : (
-              <Stack hasGutter>
-                <StackItem>
-                  <Title
-                    headingLevel="h3"
-                    size="4xl"
-                    aria-valuetext={`${metric} ${t(
-                      "metrics:metric_kpi_topicPartitions_name"
-                    )}`}
-                  >
-                    {metric}{" "}
-                    {(() => {
-                      if (metric === 1000) {
-                        return (
-                          <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
-                        );
-                      } else if (metric >= 950) {
-                        return (
-                          <ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />
-                        );
-                      } else {
-                        return "";
-                      }
-                    })()}
-                  </Title>
-                </StackItem>
-                <StackItem>
-                  <TextContent>
-                    <Text>{t("metrics:partition_limit")}</Text>
-                  </TextContent>
-                </StackItem>
-              </Stack>
-            ))}
-          {isLoading && <Skeleton width="50px" shape="square" />}
-        </Bullseye>
+            </Bullseye>
+          ) : (
+            <>
+              <Title
+                headingLevel="h3"
+                size="4xl"
+                aria-valuetext={`${metric} ${t(
+                  "metrics:metric_kpi_topicPartitions_name"
+                )}`}
+              >
+                {metric}{" "}
+                {(() => {
+                  if (metric === topicPartitionsLimit) {
+                    return (
+                      <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
+                    );
+                  } else if (metric >= topicPartitionsLimit * 0.95) {
+                    return (
+                      <ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />
+                    );
+                  } else {
+                    return "";
+                  }
+                })()}
+              </Title>
+              <TextContent>
+                <Text>
+                  {t("metrics:partition_limit", {
+                    topic: topicPartitionsLimit,
+                  })}
+                </Text>
+              </TextContent>
+            </>
+          ))}
+        {isLoading && <Skeleton width="50px" shape="square" />}
       </CardBody>
       {(() => {
-        if (metric && metric === 1000) {
+        if (metric && metric === topicPartitionsLimit) {
           return (
             <CardFooter>
               <Alert
@@ -101,7 +101,7 @@ export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
               </Alert>
             </CardFooter>
           );
-        } else if (metric && metric >= 950) {
+        } else if (metric && metric >= topicPartitionsLimit * 0.95) {
           return (
             <CardFooter>
               <Alert
@@ -111,7 +111,11 @@ export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
                 variant={AlertVariant.warning}
                 title={t("metrics:partition_limit_approaching_title")}
               >
-                <p>{t("metrics:partition_limit_approaching_description_1")}</p>
+                <p>
+                  {t("metrics:partition_limit_approaching_description_1", {
+                    limit: topicPartitionsLimit,
+                  })}
+                </p>
                 <p>{t("metrics:partition_limit_approaching_description_2")}</p>
               </Alert>
             </CardFooter>

--- a/src/Kafka/Metrics/components/PartitionCard.tsx
+++ b/src/Kafka/Metrics/components/PartitionCard.tsx
@@ -1,0 +1,125 @@
+import {
+  Bullseye,
+  Card,
+  CardBody,
+  CardTitle,
+  Skeleton,
+  TextContent,
+  Title,
+  Text,
+  CardFooter,
+  Alert,
+  Stack,
+  StackItem,
+  AlertVariant,
+} from "@patternfly/react-core";
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from "@patternfly/react-icons";
+import { VoidFunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+import { ChartPopover } from "./ChartPopover";
+import { EmptyStateNoMetricsData } from "./EmptyStateNoMetricsData";
+
+type PartitionCardProps = {
+  metric: string | number | undefined;
+  isLoading: boolean;
+};
+
+export const PartitionCard: VoidFunctionComponent<PartitionCardProps> = ({
+  metric,
+  isLoading,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Card
+      isFullHeight
+      data-testid={t("metrics:metric_kpi_topicPartitions_name")}
+    >
+      <CardTitle component="h3">
+        {t("metrics:metric_kpi_topicPartitions_name")}{" "}
+        <ChartPopover
+          title={t("metrics:metric_kpi_topicPartitions_name")}
+          description={t("metrics:metric_kpi_topicPartitions_description")}
+        />
+      </CardTitle>
+      <CardBody>
+        <Bullseye>
+          {!isLoading &&
+            (metric === undefined ? (
+              <EmptyStateNoMetricsData />
+            ) : (
+              <Stack hasGutter>
+                <StackItem>
+                  <Title
+                    headingLevel="h3"
+                    size="4xl"
+                    aria-valuetext={`${metric} ${t(
+                      "metrics:metric_kpi_topicPartitions_name"
+                    )}`}
+                  >
+                    {metric}{" "}
+                    {(() => {
+                      if (metric === 1000) {
+                        return (
+                          <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
+                        );
+                      } else if (metric >= 950) {
+                        return (
+                          <ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />
+                        );
+                      } else {
+                        return "";
+                      }
+                    })()}
+                  </Title>
+                </StackItem>
+                <StackItem>
+                  <TextContent>
+                    <Text>{t("metrics:partition_limit")}</Text>
+                  </TextContent>
+                </StackItem>
+              </Stack>
+            ))}
+          {isLoading && <Skeleton width="50px" shape="square" />}
+        </Bullseye>
+      </CardBody>
+      {(() => {
+        if (metric && metric === 1000) {
+          return (
+            <CardFooter>
+              <Alert
+                isExpandable
+                isInline
+                variant={AlertVariant.danger}
+                title={t("metrics:partition_limit_reached_title")}
+              >
+                <p>{t("metrics:partition_limit_reached_description_1")}</p>
+                <p>{t("metrics:partition_limit_reached_description_2")}</p>
+              </Alert>
+            </CardFooter>
+          );
+        } else if (metric && metric >= 950) {
+          return (
+            <CardFooter>
+              <Alert
+                role={"alert"}
+                isExpandable
+                isInline
+                variant={AlertVariant.warning}
+                title={t("metrics:partition_limit_approaching_title")}
+              >
+                <p>{t("metrics:partition_limit_approaching_description_1")}</p>
+                <p>{t("metrics:partition_limit_approaching_description_2")}</p>
+              </Alert>
+            </CardFooter>
+          );
+        } else {
+          return " ";
+        }
+      })()}
+    </Card>
+  );
+};

--- a/src/Kafka/Metrics/machines/MetricsKpiMachine.ts
+++ b/src/Kafka/Metrics/machines/MetricsKpiMachine.ts
@@ -37,6 +37,7 @@ export const MetricsKpiMachine = createMachine(
         topics: number | undefined;
         topicPartitions: number | undefined;
         consumerGroups: number | undefined;
+        topicPartitionsLimit: number | undefined;
 
         // how many time did we try a fetch (that combines more api)
         fetchFailures: number;
@@ -52,6 +53,7 @@ export const MetricsKpiMachine = createMachine(
       topics: undefined,
       topicPartitions: undefined,
       consumerGroups: undefined,
+      topicPartitionsLimit: undefined,
       fetchFailures: 0,
     },
     initial: "initialLoading",
@@ -130,11 +132,17 @@ export const MetricsKpiMachine = createMachine(
   {
     actions: {
       setMetrics: assign((_, event) => {
-        const { topics, topicPartitions, consumerGroups } = event;
+        const {
+          topics,
+          topicPartitions,
+          consumerGroups,
+          topicPartitionsLimit,
+        } = event;
         return {
           topics,
           topicPartitions,
           consumerGroups,
+          topicPartitionsLimit,
         };
       }),
 
@@ -154,7 +162,8 @@ export const MetricsKpiMachine = createMachine(
           return (
             event.topics !== undefined ||
             event.topicPartitions !== undefined ||
-            event.consumerGroups !== undefined
+            event.consumerGroups !== undefined ||
+            event.topicPartitionsLimit !== undefined
           );
         }
         return false;

--- a/src/Kafka/Metrics/storiesHelpers.ts
+++ b/src/Kafka/Metrics/storiesHelpers.ts
@@ -33,7 +33,12 @@ export const getMetricsKpi = ({
   waitLengthMs,
 }: { waitLengthMs?: number } = {}) => {
   return fakeApi<GetMetricsKpiResponse>(
-    { topics: 3, topicPartitions: 6, consumerGroups: 12 },
+    {
+      topics: 3,
+      topicPartitions: 6,
+      consumerGroups: 12,
+      topicPartitionsLimit: 1000,
+    },
     waitLengthMs
   );
 };

--- a/src/Kafka/Metrics/types.ts
+++ b/src/Kafka/Metrics/types.ts
@@ -35,4 +35,5 @@ export type GetMetricsKpiResponse = {
   topics: number;
   topicPartitions: number;
   consumerGroups: number;
+  topicPartitionsLimit: number;
 };

--- a/src/Kafka/Metrics/useMetricsKpi.tsx
+++ b/src/Kafka/Metrics/useMetricsKpi.tsx
@@ -19,6 +19,7 @@ export function useMetricsKpi() {
   const {
     topics,
     topicPartitions,
+    topicPartitionsLimit,
     consumerGroups,
     isInitialLoading,
     isLoading,
@@ -38,6 +39,7 @@ export function useMetricsKpi() {
     topics,
     topicPartitions,
     consumerGroups,
+    topicPartitionsLimit,
     onRefresh,
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

>  Add partition limit message to the topic partitions card
> Add Metrics lag message to the dashboard

**Which issue(s) this PR fixes** 

> https://issues.redhat.com/browse/MGDSTRM-7799
> https://issues.redhat.com/browse/MGDSTRM-8180

**Verification steps** 
kafka > Metrics > Components > Partition Card


