### PR TITLE
Large kafka updates

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,4 +11,13 @@ module.exports = {
     "node_modules/(?!@patternfly/react-icons|@patternfly/react-tokens|@novnc|@popperjs|lodash|monaco-editor|react-monaco-editor|byte-size)",
   ],
   setupFilesAfterEnv: ["<rootDir>/setupJest.ts"],
+  coveragePathIgnorePatterns: [
+    "node_modules",
+    "__mocks__",
+    "setupJest.ts",
+    "<rootDir>/src/ProofOfConcepts",
+    "<rootDir>/src/test-utils.tsx",
+    "storiesHelpers.ts",
+    ".*.stories.tsx",
+  ],
 };

--- a/locales/en/create-kafka-instance-with-sizes.json
+++ b/locales/en/create-kafka-instance-with-sizes.json
@@ -32,7 +32,7 @@
     "unknown_error_title": "$t(common:something_went_wrong)"
   },
   "ingress_value": "up to {{value}} MiB/second",
-  "instance_creation_time_alert": "Your Kafka instance will be ready for use shortly after creation.",
+  "instance_creation_time_alert": "Your $t(common:kafka) instance will be ready for use shortly after creation.",
   "instance_information": "Details",
   "instance_name": "Name",
   "kafka_status_created_shortly_help": "This will be ready shortly.",
@@ -49,7 +49,7 @@
       "title": "Preparing"
     },
     "provisioning": {
-      "description": "Creating Kafka instance",
+      "description": "Creating $t(common:kafka) instance",
       "title": "Provisioning"
     },
     "title": "Creating instance",
@@ -83,9 +83,11 @@
   "select_cloud_provider": "Select cloud provider",
   "select_region": "Select region",
   "size_field_aria": "More info for Size field",
-  "size_help_content": "Size of a Kafka instance is based on streaming units. The number of streaming units defines the capacity, resources, and limits of an instance. An instance with a larger size can handle higher loads and process larger amounts of events, has more storage, and can handle more clients and connections.",
-  "sizes_missing": "Size options display when a cloud provider and region are selected",
+  "size_help_content": "Size of a $t(common:kafka) instance is based on streaming units. The number of streaming units defines the capacity, resources, and limits of an instance. An instance with a larger size can handle higher loads and process larger amounts of events, has more storage, and can handle more clients and connections.",
+  "size_preview_message": "The selected $t(common:kafka) instance size is available only as a Technology Preview at this time. Refer to the <0>service definition</0> for more details.",
+  "size_preview_title": "Technology Preview",
   "sizes_error": "$t(common:something_went_wrong) while fetching the available sizes. Select another cloud provider or cloud region, or try again later.",
+  "sizes_missing": "Size options display when a cloud provider and region are selected",
   "some_region_unavailable_helper_text": "One or more regions in the selected cloud provider are temporarily unavailable. Select an available region or try again later.",
   "standard_kafka_size_description": "Learn how to add streaming units to your account",
   "standard_kafka_streaming_unit": "Your organization has {{count}} streaming unit remaining",

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
@@ -54,6 +54,7 @@ const CreateKafkaInstanceMachine = createMachine(
         creationError: CreateKafkaInstanceError | undefined;
       },
       events: {} as
+        | { type: "fieldChange" }
         | { type: "formChange" }
         | { type: "nameChange"; name: string }
         | { type: "providerChange"; provider: Provider }
@@ -172,7 +173,7 @@ const CreateKafkaInstanceMachine = createMachine(
             },
             on: {
               nameChange: {
-                actions: ["setName", "formChange"],
+                actions: ["setName", "fieldChange"],
                 target: ".validate",
               },
             },
@@ -197,7 +198,7 @@ const CreateKafkaInstanceMachine = createMachine(
             },
             on: {
               providerChange: {
-                actions: ["setProvider", "formChange"],
+                actions: ["setProvider", "fieldChange"],
                 target: ".validate",
               },
             },
@@ -222,7 +223,7 @@ const CreateKafkaInstanceMachine = createMachine(
             },
             on: {
               regionChange: {
-                actions: ["setRegion", "formChange"],
+                actions: ["setRegion", "fieldChange"],
                 target: ".validate",
               },
             },
@@ -266,11 +267,14 @@ const CreateKafkaInstanceMachine = createMachine(
               },
             },
             on: {
-              formChange: {
+              providerChange: {
+                target: ".validate",
+              },
+              regionChange: {
                 target: ".validate",
               },
               sizeChange: {
-                actions: ["setSize", "formChange"],
+                actions: ["setSize", "fieldChange"],
                 target: ".validate",
               },
             },
@@ -385,7 +389,7 @@ const CreateKafkaInstanceMachine = createMachine(
           },
         };
       }),
-      formChange: send("formChange"),
+      fieldChange: send("formChange"),
       setName: assign((context, { name }) => {
         if (context.creationError === "name-taken") {
           return { form: { ...context.form, name }, creationError: undefined };

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
@@ -24,7 +24,7 @@ export const SYSTEM_UNAVAILABLE = "systemUnavailable";
 export const SIZE_IDLE = "sizeIdle";
 export const SIZE_LOADING = "sizeLoading";
 export const SIZE_VALID = "sizeValid";
-export const SIZE_INVALID = "sizeInvalid";
+export const SIZE_OVER_QUOTA = "sizeOverQuota";
 export const SIZE_ERROR = "sizeError";
 
 const CreateKafkaInstanceMachine = createMachine(
@@ -235,15 +235,15 @@ const CreateKafkaInstanceMachine = createMachine(
                   { cond: "noProviderAndRegion", target: "idle" },
                   { cond: "noSizes", target: "loading" },
                   { cond: "emptySizes", target: "error" },
-                  { cond: "sizeIsValid", target: "valid" },
-                  { target: "invalid" },
+                  { cond: "sizeIsInQuota", target: "valid" },
+                  { target: "overQuota" },
                 ],
               },
               idle: {
                 tags: SIZE_IDLE,
               },
-              invalid: {
-                tags: SIZE_INVALID,
+              overQuota: {
+                tags: SIZE_OVER_QUOTA,
               },
               valid: {
                 tags: SIZE_VALID,
@@ -492,7 +492,7 @@ const CreateKafkaInstanceMachine = createMachine(
         form.provider === undefined || form.region === undefined,
       noSizes: ({ sizes }) => sizes === undefined,
       emptySizes: ({ sizes }) => sizes !== undefined && sizes.length === 0,
-      sizeIsValid: ({ form, capabilities }) =>
+      sizeIsInQuota: ({ form, capabilities }) =>
         capabilities !== undefined &&
         form.size !== undefined &&
         form.size.quota <= capabilities.remainingQuota,

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
@@ -414,6 +414,7 @@ const CreateKafkaInstanceMachine = createMachine(
         if (context.creationError === "region-unavailable") {
           return {
             form: { ...context.form, region },
+            sizes: undefined,
             creationError: undefined,
           };
         }
@@ -422,6 +423,7 @@ const CreateKafkaInstanceMachine = createMachine(
             ...context.form,
             region,
           },
+          sizes: undefined,
         };
       }),
       setSize: assign((context, { size }) => ({

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
@@ -322,7 +322,7 @@ const CreateKafkaInstanceMachine = createMachine(
           availableProviders,
           defaultProvider,
           instanceAvailability,
-          remainingStreamingUnits,
+          remainingQuota,
           maxStreamingUnits,
           plan,
         } = event.data;
@@ -366,7 +366,7 @@ const CreateKafkaInstanceMachine = createMachine(
           capabilities: {
             availableProviders,
             defaultProvider,
-            remainingStreamingUnits,
+            remainingQuota,
             maxStreamingUnits,
             plan,
             instanceAvailability: computedInstanceAvailability,
@@ -376,9 +376,7 @@ const CreateKafkaInstanceMachine = createMachine(
       }),
       setSizes: assign((context, event) => {
         const sizes: Size[] = [...event.data.sizes];
-        const smallestSize = sizes.sort(
-          (a, b) => a.streamingUnits - b.streamingUnits
-        )[0];
+        const smallestSize = sizes.sort((a, b) => a.quota - b.quota)[0];
         return {
           sizes,
           form: {
@@ -497,7 +495,7 @@ const CreateKafkaInstanceMachine = createMachine(
       sizeIsValid: ({ form, capabilities }) =>
         capabilities !== undefined &&
         form.size !== undefined &&
-        form.size.streamingUnits <= capabilities.remainingStreamingUnits,
+        form.size.quota <= capabilities.remainingQuota,
       canCreateInstances: ({ capabilities }) =>
         capabilities !== undefined &&
         capabilities.plan !== undefined &&

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.typegen.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.typegen.ts
@@ -65,7 +65,7 @@ export interface Typegen0 {
     noProviderAndRegion: "";
     noSizes: "";
     emptySizes: "";
-    sizeIsValid: "";
+    sizeIsInQuota: "";
   };
   eventsCausingDelays: {};
   matchesStates:
@@ -99,7 +99,7 @@ export interface Typegen0 {
     | "configuring.size"
     | "configuring.size.validate"
     | "configuring.size.idle"
-    | "configuring.size.invalid"
+    | "configuring.size.overQuota"
     | "configuring.size.valid"
     | "configuring.size.error"
     | "configuring.size.loading"
@@ -127,7 +127,7 @@ export interface Typegen0 {
               size?:
                 | "validate"
                 | "idle"
-                | "invalid"
+                | "overQuota"
                 | "valid"
                 | "error"
                 | "loading";
@@ -146,7 +146,7 @@ export interface Typegen0 {
     | "regionInvalid"
     | "regionValid"
     | "sizeIdle"
-    | "sizeInvalid"
+    | "sizeOverQuota"
     | "sizeValid"
     | "sizeError"
     | "sizeLoading";

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.typegen.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.typegen.ts
@@ -6,7 +6,11 @@ export interface Typegen0 {
     setAvailableProvidersAndDefault: "done.invoke.createKafkaInstance.loading:invocation[0]";
     resetCreationErrorMessage: "formChange" | "";
     setName: "nameChange";
-    formChange: "nameChange" | "providerChange" | "regionChange" | "sizeChange";
+    fieldChange:
+      | "nameChange"
+      | "providerChange"
+      | "regionChange"
+      | "sizeChange";
     setProvider: "providerChange";
     setRegion: "regionChange";
     setSize: "sizeChange";

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceProvider.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceProvider.tsx
@@ -15,8 +15,8 @@ import {
   REGION_VALID,
   SIZE_ERROR,
   SIZE_IDLE,
-  SIZE_INVALID,
   SIZE_LOADING,
+  SIZE_OVER_QUOTA,
   SYSTEM_UNAVAILABLE,
 } from "./CreateKafkaInstanceMachine";
 import {
@@ -100,7 +100,7 @@ export function useCreateKafkaInstanceMachine() {
           isNameTaken ||
           (!state.hasTag(NAME_VALID) && isFormInvalid),
         isNameTaken,
-        isSizeInvalid: state.hasTag(SIZE_INVALID),
+        isSizeOverQuota: state.hasTag(SIZE_OVER_QUOTA),
         isSizeError: state.hasTag(SIZE_ERROR),
         isSizeAvailable: !state.hasTag(SIZE_IDLE),
 

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.stories.tsx
@@ -16,7 +16,7 @@ export default {
     apiDefaultProvider: "aws",
     apiRegionsAvailability: "full",
     apiMaxStreamingUnits: 5,
-    apiRemainingStreamingUnits: 3,
+    apiRemainingQuota: 3,
     apiLatency: 500,
     onCreate: (_data, onSuccess) => setTimeout(onSuccess, 500),
   },

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.test.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.test.tsx
@@ -1,5 +1,8 @@
+import { composeStories } from "@storybook/testing-react";
 import { renderDialog, waitForI18n } from "../../test-utils";
-import { CreateKafkaInstanceWithSizes } from "./CreateKafkaInstanceWithSizes.stories";
+import * as stories from "./CreateKafkaInstanceWithSizes.stories";
+
+const { CreateKafkaInstanceWithSizes } = composeStories(stories);
 
 describe("CreateKafkaInstanceWithSizes", () => {
   it("should persist ouiaComponentId of create instance button", async () => {

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -308,7 +308,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
     FieldSizeProps,
     "onLearnHowToAddStreamingUnits" | "onLearnMoreAboutSizes"
   >
-> = () => {
+> = ({ onLearnHowToAddStreamingUnits, onLearnMoreAboutSizes }) => {
   const {
     form,
     capabilities,
@@ -333,12 +333,8 @@ export const ConnectedFieldSize: VoidFunctionComponent<
       isError={isSizeError}
       validity={isTrial ? "trial" : isSizeInvalid ? "over-quota" : "valid"}
       onChange={setSize}
-      onLearnHowToAddStreamingUnits={function (): void {
-        throw new Error("Function not implemented.");
-      }}
-      onLearnMoreAboutSizes={function (): void {
-        throw new Error("Function not implemented.");
-      }}
+      onLearnHowToAddStreamingUnits={onLearnHowToAddStreamingUnits}
+      onLearnMoreAboutSizes={onLearnMoreAboutSizes}
     />
   );
 };

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -314,7 +314,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
     capabilities,
     sizes,
     isSizeAvailable,
-    isSizeInvalid,
+    isSizeOverQuota,
     isSizeError,
     isFormEnabled,
     isLoadingSizes,
@@ -331,7 +331,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
       isDisabled={!isFormEnabled || sizes === undefined}
       isLoading={isLoading || isLoadingSizes}
       isError={isSizeError}
-      validity={isTrial ? "trial" : isSizeInvalid ? "over-quota" : "valid"}
+      validity={isTrial ? "trial" : isSizeOverQuota ? "over-quota" : "valid"}
       onChange={setSize}
       onLearnHowToAddStreamingUnits={onLearnHowToAddStreamingUnits}
       onLearnMoreAboutSizes={onLearnMoreAboutSizes}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -40,15 +40,16 @@ export type CreateKafkaInstancePropsWithSizes =
   ConnectedCreateKafkaInstanceWithSizesProps & MakeCreateKafkaInstanceMachine;
 export const CreateKafkaInstanceWithSizes: FunctionComponent<
   CreateKafkaInstancePropsWithSizes
-> = ({ getAvailableProvidersAndDefaults, getSizes, onCreate, ...props }) => (
-  <CreateKafkaInstanceProvider
-    getAvailableProvidersAndDefaults={getAvailableProvidersAndDefaults}
-    getSizes={getSizes}
-    onCreate={onCreate}
-  >
-    <ConnectedCreateKafkaInstanceWithSizes {...props} />
-  </CreateKafkaInstanceProvider>
-);
+> = ({ getAvailableProvidersAndDefaults, getSizes, onCreate, ...props }) =>
+  props.isModalOpen ? (
+    <CreateKafkaInstanceProvider
+      getAvailableProvidersAndDefaults={getAvailableProvidersAndDefaults}
+      getSizes={getSizes}
+      onCreate={onCreate}
+    >
+      <ConnectedCreateKafkaInstanceWithSizes {...props} />
+    </CreateKafkaInstanceProvider>
+  ) : null;
 
 export type ConnectedCreateKafkaInstanceWithSizesProps = {
   /**

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -169,7 +169,7 @@ export const ConnectedCreateKafkaInstanceWithSizes: VoidFunctionComponent<
             error={error}
             onClickContactUS={onClickContactUs}
             maxStreamingUnits={capabilities?.maxStreamingUnits}
-            streamingUnits={capabilities?.remainingStreamingUnits}
+            streamingUnits={capabilities?.remainingQuota}
           />
           <Form onSubmit={onSubmit} id={FORM_ID}>
             <ConnectedFieldInstanceName />
@@ -200,7 +200,7 @@ export const ConnectedCreateKafkaInstanceWithSizes: VoidFunctionComponent<
               connectionRate={selectedSize.connectionRate}
               messageSize={selectedSize.messageSize}
               onClickQuickStart={onClickQuickStart}
-              streamingUnits={selectedSize.streamingUnits}
+              streamingUnits={selectedSize.displayName}
             />
           )}
         </FlexItem>
@@ -325,9 +325,9 @@ export const ConnectedFieldSize: VoidFunctionComponent<
 
   return (
     <FieldSize
-      value={form.size?.streamingUnits || 1}
+      value={form.size?.quota || 1}
       sizes={isSizeAvailable ? sizes : undefined}
-      remainingStreamingUnits={capabilities?.remainingStreamingUnits || 0}
+      remainingQuota={capabilities?.remainingQuota || 0}
       isDisabled={!isFormEnabled || sizes === undefined}
       isLoading={isLoading || isLoadingSizes}
       isError={isSizeError}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormLoad.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormLoad.stories.tsx
@@ -11,7 +11,7 @@ export default {
     apiDefaultProvider: "aws",
     apiRegionsAvailability: "full",
     apiMaxStreamingUnits: 5,
-    apiRemainingStreamingUnits: 3,
+    apiRemainingQuota: 3,
     apiLatency: 500,
     onCreate: (_data, onSuccess) => setTimeout(onSuccess, 500),
   },

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormProcessing.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormProcessing.stories.tsx
@@ -17,7 +17,7 @@ export default {
     apiDefaultProvider: "aws",
     apiRegionsAvailability: "full",
     apiMaxStreamingUnits: 5,
-    apiRemainingStreamingUnits: 3,
+    apiRemainingQuota: 3,
     apiLatency: 500,
     onCreate: (_data, onSuccess) => setTimeout(onSuccess, 500),
   },

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormSubmit.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormSubmit.stories.tsx
@@ -19,7 +19,7 @@ export default {
     apiDefaultProvider: "aws",
     apiRegionsAvailability: "full",
     apiMaxStreamingUnits: 5,
-    apiRemainingStreamingUnits: 3,
+    apiRemainingQuota: 3,
     apiLatency: 500,
     onCreate: (_data, onSuccess) => setTimeout(onSuccess, 500),
   },

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/Variants.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/Variants.stories.tsx
@@ -11,7 +11,7 @@ export default {
     apiDefaultProvider: "aws",
     apiRegionsAvailability: "full",
     apiMaxStreamingUnits: 5,
-    apiRemainingStreamingUnits: 3,
+    apiRemainingQuota: 3,
     apiLatency: 500,
     onCreate: (_data, onSuccess) => setTimeout(onSuccess, 500),
   },

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
@@ -54,7 +54,9 @@ const SIZES: { [key: string]: Size[] } = {
   aws: [
     {
       id: "x1",
-      streamingUnits: 1,
+      displayName: "1",
+      quota: 1,
+      status: "stable",
       ingress: 3,
       egress: 31,
       storage: 5,
@@ -65,7 +67,9 @@ const SIZES: { [key: string]: Size[] } = {
     },
     {
       id: "x2",
-      streamingUnits: 2,
+      displayName: "2",
+      quota: 2,
+      status: "preview",
       ingress: 30,
       egress: 301,
       storage: 50,
@@ -76,7 +80,9 @@ const SIZES: { [key: string]: Size[] } = {
     },
     {
       id: "x3",
-      streamingUnits: 5,
+      displayName: "3",
+      quota: 5,
+      status: "preview",
       ingress: 300,
       egress: 3001,
       storage: 500,
@@ -89,7 +95,9 @@ const SIZES: { [key: string]: Size[] } = {
   azure: [
     {
       id: "x1",
-      streamingUnits: 3,
+      displayName: "1",
+      quota: 3,
+      status: "preview",
       ingress: 3,
       egress: 31,
       storage: 5,
@@ -100,7 +108,9 @@ const SIZES: { [key: string]: Size[] } = {
     },
     {
       id: "x2",
-      streamingUnits: 9,
+      displayName: "2",
+      quota: 9,
+      status: "preview",
       ingress: 30,
       egress: 301,
       storage: 50,
@@ -119,7 +129,7 @@ export function makeAvailableProvidersAndDefaults(
     defaultProvider: Provider | undefined;
     providers: string[];
     maxStreamingUnits: number;
-    remainingStreamingUnits: number;
+    remainingQuota: number;
   },
   allProviders = PROVIDERS,
   latency = 500
@@ -129,7 +139,7 @@ export function makeAvailableProvidersAndDefaults(
     defaultProvider,
     providers,
     maxStreamingUnits,
-    remainingStreamingUnits,
+    remainingQuota,
     plan,
   } = options;
   const availableProviders = allProviders.filter((p) =>
@@ -144,7 +154,7 @@ export function makeAvailableProvidersAndDefaults(
         availableProviders,
         instanceAvailability,
         maxStreamingUnits,
-        remainingStreamingUnits,
+        remainingQuota,
       },
       latency
     );
@@ -220,7 +230,7 @@ export const argTypes = {
       max: 9,
     },
   },
-  apiRemainingStreamingUnits: {
+  apiRemainingQuota: {
     control: {
       type: "range",
       min: 0,
@@ -270,7 +280,7 @@ export const Template: ComponentStory<typeof CreateKafkaInstanceWithSizes> = (
     apiDefaultRegion,
     apiRegionsAvailability = "full",
     apiSizes = "normal",
-    apiRemainingStreamingUnits = 3,
+    apiRemainingQuota = 3,
     apiMaxStreamingUnits = 5,
     apiLatency = 500,
   } = args as { [key: string]: any };
@@ -312,7 +322,7 @@ export const Template: ComponentStory<typeof CreateKafkaInstanceWithSizes> = (
             instanceAvailability: apiScenario,
             defaultProvider: apiDefaultProvider,
             providers: apiProviders,
-            remainingStreamingUnits: apiRemainingStreamingUnits,
+            remainingQuota: apiRemainingQuota,
             maxStreamingUnits: apiMaxStreamingUnits,
           },
           providers,

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldAZ.test.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldAZ.test.tsx
@@ -1,0 +1,25 @@
+import { userEvent } from "@storybook/testing-library";
+import { render, waitForI18n } from "../../../test-utils";
+import { FieldAZ } from "./FieldAZ";
+
+describe("FieldAZ", () => {
+  it("can change value", async () => {
+    const changeSpy = jest.fn();
+
+    const comp = render(
+      <FieldAZ
+        options={"all"}
+        onChange={changeSpy}
+        isDisabled={false}
+        validity={"valid"}
+        value={undefined}
+      />
+    );
+    await waitForI18n(comp);
+    expect(changeSpy).toBeCalledTimes(0);
+    userEvent.click(comp.getByText("Single"));
+    expect(changeSpy).toHaveBeenLastCalledWith("single");
+    userEvent.click(comp.getByText("Multi"));
+    expect(changeSpy).toHaveBeenLastCalledWith("multi");
+  });
+});

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
@@ -5,16 +5,16 @@ import { Size } from "../types";
 import { FieldSize as FieldSizeComp } from "./FieldSize";
 
 const sizes = [
-  { id: "x1", streamingUnits: 1 },
-  { id: "x2", streamingUnits: 3 },
-  { id: "x3", streamingUnits: 5 },
-  { id: "x4", streamingUnits: 10 },
-  { id: "x5", streamingUnits: 15 },
+  { id: "x1", displayName: "1", status: "stable", quota: 1 },
+  { id: "x2", displayName: "2", status: "preview", quota: 3 },
+  { id: "x3", displayName: "3", status: "preview", quota: 5 },
+  { id: "x4", displayName: "4", status: "preview", quota: 10 },
+  { id: "x5", displayName: "5", status: "preview", quota: 15 },
 ] as Size[];
 
 const summitSizes = [
-  { id: "x1", streamingUnits: 1 },
-  { id: "x2", streamingUnits: 2 },
+  { id: "x1", displayName: "1", status: "stable", quota: 1 },
+  { id: "x2", displayName: "2", status: "preview", quota: 2 },
 ] as Size[];
 
 export default {
@@ -22,7 +22,7 @@ export default {
   args: {
     value: 1,
     sizes,
-    remainingStreamingUnits: 4,
+    remainingQuota: 4,
     validity: "valid",
     isDisabled: false,
     isLoading: false,
@@ -56,7 +56,7 @@ LoadingSizes.args = {
 export const OverQuota = Template.bind({});
 OverQuota.args = {
   value: 1,
-  remainingStreamingUnits: 0,
+  remainingQuota: 0,
   validity: "over-quota",
 };
 
@@ -69,7 +69,7 @@ export const MvpOverQuota = Template.bind({});
 MvpOverQuota.args = {
   value: 2,
   sizes: summitSizes,
-  remainingStreamingUnits: 1,
+  remainingQuota: 1,
   validity: "over-quota",
 };
 
@@ -77,6 +77,6 @@ export const Trial = Template.bind({});
 Trial.args = {
   value: 1,
   sizes: summitSizes,
-  remainingStreamingUnits: 1,
+  remainingQuota: 1,
   validity: "trial",
 };

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
@@ -42,6 +42,11 @@ const Template: ComponentStory<typeof FieldSizeComp> = (args) => (
 
 export const Default = Template.bind({});
 
+export const TechPreview = Template.bind({});
+TechPreview.args = {
+  value: 3,
+};
+
 export const NoSizes = Template.bind({});
 NoSizes.args = {
   sizes: undefined,

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
@@ -1,16 +1,11 @@
-import {
-  Button,
-  ButtonVariant,
-  HelperText,
-  HelperTextItem,
-  Skeleton,
-  Slider,
-  SliderProps,
-} from "@patternfly/react-core";
+import { Skeleton, Slider, SliderProps } from "@patternfly/react-core";
 import { VoidFunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroupWithPopover } from "../../../shared";
 import { Size } from "../types";
+import { FieldSizeHelperText } from "./FieldSizeHelperText";
+import { FieldSizeHelperTextOverQuota } from "./FieldSizeHelperTextOverQuota";
+import { FieldSizeHelperTextTrial } from "./FieldSizeHelperTextTrial";
 
 export type FieldSizeProps = {
   value: number;
@@ -41,47 +36,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
   const isRequired = validity !== "trial";
 
   const helperTextTrial = (
-    <>
-      <HelperText className={"pf-c-form__helper-text"}>
-        <HelperTextItem>{t("trial_kafka_size_description")}</HelperTextItem>
-      </HelperText>
-      <HelperText>
-        <HelperTextItem>
-          <Button
-            className="pf-c-form__helper-text"
-            variant={ButtonVariant.link}
-            isInline
-            onClick={onLearnMoreAboutSizes}
-          >
-            {t("learn_about_sizes")}
-          </Button>
-        </HelperTextItem>
-      </HelperText>
-    </>
-  );
-
-  const helperTextOverQuota = (
-    <>
-      <HelperText className={"pf-c-form__helper-text"}>
-        <HelperTextItem variant="error" hasIcon>
-          {t("standard_kafka_streaming_unit", {
-            count: remainingQuota,
-          })}
-        </HelperTextItem>
-      </HelperText>
-      <HelperText>
-        <HelperTextItem>
-          <Button
-            className="pf-c-form__helper-text"
-            variant={ButtonVariant.link}
-            isInline
-            onClick={onLearnHowToAddStreamingUnits}
-          >
-            {t("standard_kafka_size_description")}
-          </Button>
-        </HelperTextItem>
-      </HelperText>
-    </>
+    <FieldSizeHelperTextTrial onClick={onLearnMoreAboutSizes} />
   );
 
   if (isLoading || isError) {
@@ -113,12 +68,27 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       />
     );
   }
+
   const valueIndex =
     validity !== "trial" ? sizes.findIndex((size) => size.quota === value) : -1;
+
   const steps: SliderProps["customSteps"] = sizes.map((s, index) => ({
     value: index,
     label: `${s.quota}`,
   }));
+
+  const helperText = (
+    <FieldSizeHelperText
+      remainingQuota={remainingQuota}
+      isPreview={sizes[valueIndex]?.status === "preview"}
+    />
+  );
+  const helperTextOverQuota = (
+    <FieldSizeHelperTextOverQuota
+      remainingQuota={remainingQuota}
+      onClick={onLearnHowToAddStreamingUnits}
+    />
+  );
 
   const handleChange = (index: number) => {
     onChange(sizes[index]);
@@ -138,13 +108,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       buttonAriaLabel={t("size_field_aria")}
       isRequired={isRequired}
       validated={validation}
-      helperText={
-        validity !== "trial"
-          ? t("standard_kafka_streaming_unit", {
-              count: remainingQuota,
-            })
-          : helperTextTrial
-      }
+      helperText={validity !== "trial" ? helperText : helperTextTrial}
       helperTextInvalid={
         validity === "over-quota" ? helperTextOverQuota : undefined
       }

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
@@ -15,7 +15,7 @@ import { Size } from "../types";
 export type FieldSizeProps = {
   value: number;
   sizes: Size[] | undefined;
-  remainingStreamingUnits: number;
+  remainingQuota: number;
   isDisabled: boolean;
   isLoading: boolean;
   isError: boolean;
@@ -27,7 +27,7 @@ export type FieldSizeProps = {
 export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
   value,
   sizes,
-  remainingStreamingUnits,
+  remainingQuota,
   isDisabled,
   isLoading,
   isError,
@@ -65,7 +65,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       <HelperText className={"pf-c-form__helper-text"}>
         <HelperTextItem variant="error" hasIcon>
           {t("standard_kafka_streaming_unit", {
-            count: remainingStreamingUnits,
+            count: remainingQuota,
           })}
         </HelperTextItem>
       </HelperText>
@@ -114,12 +114,10 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
     );
   }
   const valueIndex =
-    validity !== "trial"
-      ? sizes.findIndex((size) => size.streamingUnits === value)
-      : -1;
+    validity !== "trial" ? sizes.findIndex((size) => size.quota === value) : -1;
   const steps: SliderProps["customSteps"] = sizes.map((s, index) => ({
     value: index,
-    label: `${s.streamingUnits}`,
+    label: `${s.quota}`,
   }));
 
   const handleChange = (index: number) => {
@@ -127,8 +125,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
   };
 
   const validation =
-    (validity !== "valid" || remainingStreamingUnits < value) &&
-    validity !== "trial"
+    (validity !== "valid" || remainingQuota < value) && validity !== "trial"
       ? "error"
       : "default";
 
@@ -144,7 +141,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       helperText={
         validity !== "trial"
           ? t("standard_kafka_streaming_unit", {
-              count: remainingStreamingUnits,
+              count: remainingQuota,
             })
           : helperTextTrial
       }

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { FieldSizeHelperText as FieldSizeHelperTextComp } from "./FieldSizeHelperText";
+
+export default {
+  component: FieldSizeHelperTextComp,
+  args: {
+    remainingQuota: 4,
+    isPreview: false,
+  },
+  parameters: {
+    backgrounds: {
+      default: "Background color 100",
+    },
+  },
+} as ComponentMeta<typeof FieldSizeHelperTextComp>;
+
+const Template: ComponentStory<typeof FieldSizeHelperTextComp> = (args) => (
+  <FieldSizeHelperTextComp {...args} />
+);
+
+export const StableInstanceType = Template.bind({});
+
+export const TechPreview = Template.bind({});
+TechPreview.args = {
+  isPreview: true,
+};

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
@@ -1,0 +1,40 @@
+import { Alert, AlertVariant, HelperText } from "@patternfly/react-core";
+import { VoidFunctionComponent } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { ExternalLink } from "../../../shared";
+
+export const FieldSizeHelperText: VoidFunctionComponent<{
+  remainingQuota: number;
+  isPreview: boolean;
+}> = ({ remainingQuota, isPreview }) => {
+  const { t } = useTranslation("create-kafka-instance-with-sizes");
+  return (
+    <HelperText className={"pf-c-form__helper-text"}>
+      {t("standard_kafka_streaming_unit", {
+        count: remainingQuota,
+      })}
+
+      {isPreview && (
+        <Alert
+          aria-live="polite"
+          role={"alert"}
+          className="pf-u-mb-md pf-u-mt-lg"
+          variant={AlertVariant.info}
+          title={t("size_preview_title")}
+          isInline
+        >
+          <Trans
+            ns={"create-kafka-instance-with-sizes"}
+            i18nKey={"size_preview_message"}
+            components={[
+              <ExternalLink
+                href={"https://access.redhat.com/articles/6473891"}
+                testId={"size-preview-support-link"}
+              />,
+            ]}
+          />
+        </Alert>
+      )}
+    </HelperText>
+  );
+};

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextOverQuota.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextOverQuota.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { FieldSizeHelperTextOverQuota as FieldSizeHelperTextOverQuotaComp } from "./FieldSizeHelperTextOverQuota";
+
+export default {
+  component: FieldSizeHelperTextOverQuotaComp,
+  args: {
+    remainingQuota: 4,
+  },
+  parameters: {
+    backgrounds: {
+      default: "Background color 100",
+    },
+  },
+} as ComponentMeta<typeof FieldSizeHelperTextOverQuotaComp>;
+
+const Template: ComponentStory<typeof FieldSizeHelperTextOverQuotaComp> = (
+  args
+) => <FieldSizeHelperTextOverQuotaComp {...args} />;
+
+export const FieldSizeHelperTextOverQuota = Template.bind({});

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextOverQuota.test.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextOverQuota.test.tsx
@@ -1,0 +1,22 @@
+import { userEvent } from "@storybook/testing-library";
+import { render, waitForI18n } from "../../../test-utils";
+import { FieldSizeHelperTextOverQuota } from "./FieldSizeHelperTextOverQuota";
+
+describe("FieldSizeHelperTextOverQuota", () => {
+  it("renders", async () => {
+    const clickSpy = jest.fn();
+
+    const comp = render(
+      <FieldSizeHelperTextOverQuota remainingQuota={3} onClick={clickSpy} />
+    );
+    await waitForI18n(comp);
+
+    expect(comp.getByText("Your organization has 3 streaming units remaining"));
+    expect(clickSpy).toBeCalledTimes(0);
+
+    userEvent.click(
+      comp.getByText("Learn how to add streaming units to your account")
+    );
+    expect(clickSpy).toBeCalledTimes(1);
+  });
+});

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextOverQuota.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextOverQuota.tsx
@@ -1,0 +1,38 @@
+import {
+  Button,
+  ButtonVariant,
+  HelperText,
+  HelperTextItem,
+} from "@patternfly/react-core";
+import { VoidFunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+
+export const FieldSizeHelperTextOverQuota: VoidFunctionComponent<{
+  remainingQuota: number;
+  onClick: () => void;
+}> = ({ remainingQuota, onClick }) => {
+  const { t } = useTranslation("create-kafka-instance-with-sizes");
+  return (
+    <>
+      <HelperText className={"pf-c-form__helper-text"}>
+        <HelperTextItem variant="error" hasIcon>
+          {t("standard_kafka_streaming_unit", {
+            count: remainingQuota,
+          })}
+        </HelperTextItem>
+      </HelperText>
+      <HelperText>
+        <HelperTextItem>
+          <Button
+            className="pf-c-form__helper-text"
+            variant={ButtonVariant.link}
+            isInline
+            onClick={onClick}
+          >
+            {t("standard_kafka_size_description")}
+          </Button>
+        </HelperTextItem>
+      </HelperText>
+    </>
+  );
+};

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextTrial.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextTrial.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { FieldSizeHelperTextTrial as FieldSizeHelperTextTrialComp } from "./FieldSizeHelperTextTrial";
+
+export default {
+  component: FieldSizeHelperTextTrialComp,
+  args: {},
+  parameters: {
+    backgrounds: {
+      default: "Background color 100",
+    },
+  },
+} as ComponentMeta<typeof FieldSizeHelperTextTrialComp>;
+
+const Template: ComponentStory<typeof FieldSizeHelperTextTrialComp> = (
+  args
+) => <FieldSizeHelperTextTrialComp {...args} />;
+
+export const FieldSizeHelperTextTrial = Template.bind({});

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextTrial.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperTextTrial.tsx
@@ -1,0 +1,33 @@
+import {
+  Button,
+  ButtonVariant,
+  HelperText,
+  HelperTextItem,
+} from "@patternfly/react-core";
+import { VoidFunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+
+export const FieldSizeHelperTextTrial: VoidFunctionComponent<{
+  onClick: () => void;
+}> = ({ onClick }) => {
+  const { t } = useTranslation("create-kafka-instance-with-sizes");
+  return (
+    <>
+      <HelperText className={"pf-c-form__helper-text"}>
+        <HelperTextItem>{t("trial_kafka_size_description")}</HelperTextItem>
+      </HelperText>
+      <HelperText>
+        <HelperTextItem>
+          <Button
+            className="pf-c-form__helper-text"
+            variant={ButtonVariant.link}
+            isInline
+            onClick={onClick}
+          >
+            {t("learn_about_sizes")}
+          </Button>
+        </HelperTextItem>
+      </HelperText>
+    </>
+  );
+};

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfo.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfo.stories.tsx
@@ -15,7 +15,7 @@ export default {
     connections: 123,
     connectionRate: 123,
     messageSize: 123,
-    streamingUnits: 1,
+    streamingUnits: "1",
   },
 } as ComponentMeta<typeof InstanceInfo>;
 

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfo.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfo.tsx
@@ -41,7 +41,7 @@ export type InstanceInfoLimitsProps = {
    * Message size in MiB
    */
   messageSize: number;
-  streamingUnits: number | undefined;
+  streamingUnits: string | undefined;
 };
 
 export const InstanceInfo: VoidFunctionComponent<

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/index.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/index.ts
@@ -9,3 +9,6 @@ export * from "./FieldInstanceName";
 export * from "./InstanceInfo";
 export * from "./FieldSize";
 export { InstanceInfoSkeleton } from "./InstanceInfoSkeleton";
+export { FieldSizeHelperText } from "./FieldSizeHelperText";
+export { FieldSizeHelperTextTrial } from "./FieldSizeHelperTextTrial";
+export { FieldSizeHelperTextOverQuota } from "./FieldSizeHelperTextOverQuota";

--- a/src/Kafka/CreateKafkaInstanceWithSizes/types.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/types.ts
@@ -26,7 +26,9 @@ export type Regions = Array<RegionInfo>;
 export type Providers = Array<ProviderInfo>;
 export type Size = {
   id: string;
-  streamingUnits: number;
+  displayName: string;
+  status: "stable" | "preview";
+  quota: number;
   ingress: number;
   egress: number;
   storage: number;
@@ -49,7 +51,7 @@ export type CreateKafkaInitializationData = {
   availableProviders: Providers;
   instanceAvailability: InstanceAvailability;
   maxStreamingUnits: number;
-  remainingStreamingUnits: number;
+  remainingQuota: number;
   plan: Plan;
 };
 

--- a/src/shared/ExternalLink/ExternalLink.stories.tsx
+++ b/src/shared/ExternalLink/ExternalLink.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ExternalLink as ExternalLinkComp } from "./ExternalLink";
+
+export default {
+  component: ExternalLinkComp,
+  args: {},
+} as ComponentMeta<typeof ExternalLinkComp>;
+
+const Template: ComponentStory<typeof ExternalLinkComp> = (args) => (
+  <ExternalLinkComp {...args} />
+);
+
+export const ExternalLink = Template.bind({});
+ExternalLink.args = {
+  href: "https://www.redhat.com",
+  testId: "test-id",
+  children: "Sample text",
+};

--- a/src/shared/ExternalLink/ExternalLink.test.tsx
+++ b/src/shared/ExternalLink/ExternalLink.test.tsx
@@ -1,0 +1,14 @@
+import { render } from "../../test-utils";
+import { ExternalLink } from "./ExternalLink";
+
+describe("ExternalLink", () => {
+  it("to render", () => {
+    const comp = render(
+      <ExternalLink href={"test-href"} testId={"test-id"} target={"_self"} />
+    );
+    const link = comp.getByTestId("test-id");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "test-href");
+    expect(link).toHaveAttribute("target", "_self");
+  });
+});

--- a/src/shared/ExternalLink/ExternalLink.tsx
+++ b/src/shared/ExternalLink/ExternalLink.tsx
@@ -1,0 +1,28 @@
+import { Button, ButtonProps, ButtonVariant } from "@patternfly/react-core";
+import { ExternalLinkAltIcon } from "@patternfly/react-icons/dist/js/icons/external-link-alt-icon";
+import { FunctionComponent } from "react";
+
+export type ExternaLinkProps = {
+  testId: string;
+  target?: ButtonProps["target"];
+  href: NonNullable<ButtonProps["href"]>;
+};
+
+export const ExternalLink: FunctionComponent<ExternaLinkProps> = ({
+  testId,
+  target = "_blank",
+  href,
+  children,
+}) => (
+  <Button
+    data-testid={testId}
+    isInline
+    variant={ButtonVariant.link}
+    component="a"
+    target={target}
+    href={href}
+  >
+    {children}
+    <ExternalLinkAltIcon className="pf-u-ml-xs" />
+  </Button>
+);

--- a/src/shared/ExternalLink/ExternalLink.tsx
+++ b/src/shared/ExternalLink/ExternalLink.tsx
@@ -23,6 +23,9 @@ export const ExternalLink: FunctionComponent<ExternaLinkProps> = ({
     href={href}
   >
     {children}
-    <ExternalLinkAltIcon className="pf-u-ml-xs" />
+    <span style={{ whiteSpace: "nowrap" }}>
+      &nbsp;
+      <ExternalLinkAltIcon className="pf-u-ml-xs" />
+    </span>
   </Button>
 );

--- a/src/shared/ExternalLink/index.ts
+++ b/src/shared/ExternalLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./ExternalLink";

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,6 +1,7 @@
 export * from "./DeleteModal";
 export * from "./DevelopmentPreview";
 export * from "./EmptyState";
+export * from "./ExternalLink";
 export * from "./FormGroupWithPopover";
 export * from "./FormatDate";
 export * from "./Loading";


### PR DESCRIPTION
**What this PR does / why we need it**:

Renders the size slider using a `displayName` value for the label. It still uses the quota under the hood to calculate if the selected size goes over quota, even if we still display it as a "streaming unit" to the user.

Also, add a "Tech preview" alert to the Size field for sizes flagged as "preview".
To support this alert, this adds a new `ExternalLink` shared component that eases working with the `Trans` component.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/MGDSTRM-8432

**Verification steps** 

1. Kafka > Create Kafka Instance With Sizes > Create Kafka Instance With Sizes: this shows the "Tech preview" for the second size, and the error message for over quota without the "Tech preview" alert for the third size.
2. Shared > External link > External link: this is the new component mentioned above