### PR TITLE
chore: add a GH action to lint PRs to ensure usage of proper titles and commit messages to support semantic release

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This should give us back the commit messages check we used to have with the [Semantic Pull Request Bot](https://probot.github.io/apps/semantic-pull-requests/) that doesn't work anymore because of https://github.com/zeke/semantic-pull-requests/issues/183
