### PR TITLE
feat: show dates in the UTC tz

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,11 @@
           {
             "name": "dayjs",
             "message": "Please use date-fns instead"
+          },
+          {
+            "name": "date-fns",
+            "importNames": ["format"],
+            "message": "Please use format or formatInTimeZone from date-fns-tz instead"
           }
         ]
       }

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -1,8 +1,8 @@
 {
   "all_topics": "All topics",
   "axis-label-bytes": "Bytes",
-  "axis-label-time": "Time",
-  "axis-label-time-full": "Time (HH:mm MM/dd)",
+  "axis-label-time": "UTC Time",
+  "axis-label-time-full": "UTC Time (HH:mm MM/dd)",
   "chart-popover-icon-screenreader-text": "Information about {{title}}",
   "client_connections": "Client connections",
   "client_connections_helper_text": "Client connections are the total connections across all clients over time. Clients can make multiple connections to multiple brokers in the Kafka instance. This metric enables you to review client activity in the instance and to assess available connections relative to the limit.",

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -1,8 +1,7 @@
 {
   "all_topics": "All topics",
   "axis-label-bytes": "Bytes",
-  "axis-label-time": "UTC Time",
-  "axis-label-time-full": "UTC Time (HH:mm MM/dd)",
+  "axis-label-time": "Time (UTC)",
   "chart-popover-icon-screenreader-text": "Information about {{title}}",
   "client_connections": "Client connections",
   "client_connections_helper_text": "Client connections are the total connections across all clients over time. Clients can make multiple connections to multiple brokers in the Kafka instance. This metric enables you to review client activity in the instance and to assess available connections relative to the limit.",

--- a/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.tsx
@@ -1,5 +1,3 @@
-import { FunctionComponent } from "react";
-import { useTranslation } from "react-i18next";
 import {
   TextContent,
   TextList,
@@ -7,10 +5,12 @@ import {
   TextListItemVariants,
   TextListVariants,
 } from "@patternfly/react-core";
-import { DetailsTabAlert } from "./components/DetailsTabAlert";
-import { format } from "date-fns";
+import { FunctionComponent, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { FormatDate } from "../../shared";
 import { InstanceType } from "../utils";
 import { KafkaSizeSkeleton } from "./KafkaSizeSkeleton";
+import { DetailsTabAlert } from "./components/DetailsTabAlert";
 
 export type KafkaDetailsTabProps = {
   id: string;
@@ -51,7 +51,7 @@ export const KafkaDetailsTab: FunctionComponent<KafkaDetailsTabProps> = ({
 }) => {
   const { t } = useTranslation("kafka");
 
-  const renderTextListItem = (title: string, value?: string) =>
+  const renderTextListItem = (title: string, value?: ReactNode) =>
     value && (
       <>
         <TextListItem component={TextListItemVariants.dt}>{title}</TextListItem>
@@ -125,11 +125,11 @@ export const KafkaDetailsTab: FunctionComponent<KafkaDetailsTabProps> = ({
           {renderTextListItem(t("common:owner"), owner)}
           {renderTextListItem(
             t("common:time_created"),
-            format(createdAt, "PPPP p")
+            <FormatDate date={createdAt} format={"long"} />
           )}
           {renderTextListItem(
             t("common:time_updated"),
-            format(updatedAt, "PPPP p")
+            <FormatDate date={updatedAt} format={"long"} />
           )}
           {renderTextListItem(
             t("common:cloud_provider"),

--- a/src/Kafka/KafkaInstanceDrawer/__snapshots__/KaafkaDetailsTab.test.tsx.snap
+++ b/src/Kafka/KafkaInstanceDrawer/__snapshots__/KaafkaDetailsTab.test.tsx.snap
@@ -143,7 +143,11 @@ exports[`Details Tab renders standard instance 1`] = `
             class=""
             data-pf-content="true"
           >
-            Saturday, July 2nd, 2022 12:00 AM
+            <time
+              datetime="2022-07-02T00:00:00Z"
+            >
+              Jul 2, 2022, 12:00 AM UTC
+            </time>
           </dd>
           <dt
             class=""
@@ -155,7 +159,11 @@ exports[`Details Tab renders standard instance 1`] = `
             class=""
             data-pf-content="true"
           >
-            Saturday, July 2nd, 2022 12:00 AM
+            <time
+              datetime="2022-07-02T00:00:00Z"
+            >
+              Jul 2, 2022, 12:00 AM UTC
+            </time>
           </dd>
           <dt
             class=""

--- a/src/Kafka/KafkaMessageBrowser/components/DateTimePicker.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/DateTimePicker.tsx
@@ -5,7 +5,8 @@ import {
   TimePicker,
   TimePickerProps,
 } from "@patternfly/react-core";
-import { format, formatISO, parseISO, setHours, setMinutes } from "date-fns";
+import { formatISO, parseISO, setHours, setMinutes } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { VoidFunctionComponent } from "react";
 import { DateIsoString } from "../types";
 
@@ -45,7 +46,7 @@ export const DateTimePicker: VoidFunctionComponent<DateTimePickerProps> = ({
     <InputGroup>
       <DatePicker
         isDisabled={isDisabled}
-        value={date ? format(date, "yyyy-MM-dd") : undefined}
+        value={date ? formatInTimeZone(date, "UTC", "yyyy-MM-dd") : undefined}
         onChange={onSelectCalendar}
       />
       <TimePicker

--- a/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
@@ -8,7 +8,8 @@ import {
   TextInput,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { format, formatISO, parse, parseISO } from "date-fns";
+import { formatISO, parse, parseISO } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 
 import { useState, VoidFunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
@@ -144,7 +145,9 @@ export const FilterGroup: VoidFunctionComponent<FilterGroupProps> = ({
                 onEpochChange(undefined);
               }
             }}
-            value={timestamp ? format(parseISO(timestamp), "t") : ""}
+            value={
+              timestamp ? formatInTimeZone(parseISO(timestamp), "UTC", "t") : ""
+            }
           />
         )}
       </InputGroup>

--- a/src/Kafka/Metrics/components/ChartLinearWithOptionalLimit.tsx
+++ b/src/Kafka/Metrics/components/ChartLinearWithOptionalLimit.tsx
@@ -111,12 +111,7 @@ export const ChartLinearWithOptionalLimit: VoidFunctionComponent<
             legendAllowWrap={true}
           >
             <ChartAxis
-              label={
-                "\n" +
-                (xLabel || showDate
-                  ? t("metrics:axis-label-time-full")
-                  : t("metrics:axis-label-time"))
-              }
+              label={"\n" + (xLabel || t("metrics:axis-label-time"))}
               tickValues={tickValues}
               tickFormat={(d) =>
                 dateToChartValue(d, {

--- a/src/Kafka/Metrics/components/ChartLogSizePerPartition.tsx
+++ b/src/Kafka/Metrics/components/ChartLogSizePerPartition.tsx
@@ -95,12 +95,7 @@ export const ChartLogSizePerPartition: FunctionComponent<
                 legendAllowWrap={true}
               >
                 <ChartAxis
-                  label={
-                    "\n" +
-                    (showDate
-                      ? t("metrics:axis-label-time-full")
-                      : t("metrics:axis-label-time"))
-                  }
+                  label={"\n" + t("metrics:axis-label-time")}
                   tickValues={tickValues}
                   tickFormat={(d) =>
                     dateToChartValue(d, {

--- a/src/Kafka/Metrics/components/ChartTotalBytes.tsx
+++ b/src/Kafka/Metrics/components/ChartTotalBytes.tsx
@@ -1,6 +1,3 @@
-import { TimeSeriesMetrics } from "../types";
-import { timeIntervalsMapping } from "../consts";
-
 import {
   Chart,
   ChartAxis,
@@ -14,15 +11,16 @@ import chart_color_blue_300 from "@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_orange_300 from "@patternfly/react-tokens/dist/esm/chart_color_orange_300";
 import { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { chartHeight, chartPadding } from "../consts";
-import {
-  dateToChartValue,
-  shouldShowDate,
-  formatBytes,
-  timestampsToTicks,
-} from "./utils";
+import { chartHeight, chartPadding, timeIntervalsMapping } from "../consts";
+import { TimeSeriesMetrics } from "../types";
 import { ChartSkeletonLoader } from "./ChartSkeletonLoader";
 import { useChartWidth } from "./useChartWidth";
+import {
+  dateToChartValue,
+  formatBytes,
+  shouldShowDate,
+  timestampsToTicks,
+} from "./utils";
 
 type ChartData = {
   color: string;
@@ -113,12 +111,7 @@ export const ChartTotalBytes: FunctionComponent<ChartTotalBytesProps> = ({
             width={width}
           >
             <ChartAxis
-              label={
-                "\n" +
-                (showDate
-                  ? t("metrics:axis-label-time-full")
-                  : t("metrics:axis-label-time"))
-              }
+              label={"\n" + t("metrics:axis-label-time")}
               tickValues={tickValues}
               tickCount={timeIntervalsMapping[duration].ticks}
               tickFormat={(d) =>

--- a/src/Kafka/Metrics/components/utils.ts
+++ b/src/Kafka/Metrics/components/utils.ts
@@ -18,7 +18,7 @@ export const dateToChartValue = (
   { showDate }: { showDate: boolean } = { showDate: false }
 ): string => {
   const date = fromUnixTime(timestamp / 1000);
-  return formatInTimeZone(date, "utc", showDate ? "HH:mm'\n'MM/dd" : "HH:mm");
+  return formatInTimeZone(date, "utc", showDate ? "HH:mm'\n'MMM dd" : "HH:mm");
 };
 
 export function timestampsToTicks(

--- a/src/Kafka/Metrics/components/utils.ts
+++ b/src/Kafka/Metrics/components/utils.ts
@@ -1,5 +1,5 @@
 import byteSize from "byte-size";
-import { format, utcToZonedTime } from "date-fns-tz";
+import { formatInTimeZone } from "date-fns-tz";
 import fromUnixTime from "date-fns/fromUnixTime";
 import sub from "date-fns/sub";
 import { timeIntervalsMapping } from "../consts";
@@ -18,10 +18,7 @@ export const dateToChartValue = (
   { showDate }: { showDate: boolean } = { showDate: false }
 ): string => {
   const date = fromUnixTime(timestamp / 1000);
-  return format(
-    utcToZonedTime(date, "utc"),
-    showDate ? "HH:mm'\n'MM/dd" : "HH:mm"
-  );
+  return formatInTimeZone(date, "utc", showDate ? "HH:mm'\n'MM/dd" : "HH:mm");
 };
 
 export function timestampsToTicks(

--- a/src/shared/FormatDate/FormatDate.tsx
+++ b/src/shared/FormatDate/FormatDate.tsx
@@ -1,12 +1,12 @@
 import {
   differenceInDays,
   differenceInMonths,
-  format,
   formatDistanceToNow,
   formatDuration,
   formatISO,
   intervalToDuration,
 } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { useState, VoidFunctionComponent } from "react";
 import { useInterval } from "../../utils";
 
@@ -36,9 +36,10 @@ export const FormatMapping: {
       }
     );
   },
-  long: (date) => format(date, "PPp"),
-  longWithMilliseconds: (date) => format(date, "PP, hh:mm:ss.SSS a"),
-  epoch: (date) => format(date, "t"),
+  long: (date) => formatInTimeZone(date, "UTC", "PPp zzz"),
+  longWithMilliseconds: (date) =>
+    formatInTimeZone(date, "UTC", "PP, hh:mm:ss.SSS a zzz"),
+  epoch: (date) => formatInTimeZone(date, "UTC", "t"),
 };
 
 type FormatDateProps = {


### PR DESCRIPTION
**What this PR does / why we need it**:

Dates are confusing. We found out that the consoledot guidelines recommend not localizing dates and showing them in the UTC timezone. The same ask has been made while demoing the message browser.

This PR changes the default behaviour of the `FormatDate` when used with either the `long` or `longWithMilliseconds` format to show the date in the UTC tz.

**Which issue(s) this PR fixes** 

> Replace this comment with references to related issues.
> e.g. `fixes #<issue number>`

**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`

**Is there any work left / what's next** :

> Replace this comment with pending items that need to be covered in this PR or some pending items you are planning to do in the future PR.

**Special notes for your reviewer**:
