### PR TITLE
fix: support single sizes

### DIFF
--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
@@ -81,7 +81,14 @@ MvpOverQuota.args = {
 export const Trial = Template.bind({});
 Trial.args = {
   value: 1,
-  sizes: summitSizes,
+  sizes: [{ id: "x1", quota: 1, displayName: "1", status: "stable" }],
   remainingQuota: 1,
   validity: "trial",
+};
+
+export const SingleSize = Template.bind({});
+SingleSize.args = {
+  value: 1,
+  sizes: [{ id: "x1", quota: 1, displayName: "1", status: "stable" }],
+  remainingQuota: 1,
 };

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
@@ -68,14 +68,18 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       />
     );
   }
+  const atLeastTwoSizes =
+    sizes.length > 1 ? sizes : [{ id: "", quota: "" }, ...sizes];
 
-  const valueIndex =
-    validity !== "trial" ? sizes.findIndex((size) => size.quota === value) : -1;
-
-  const steps: SliderProps["customSteps"] = sizes.map((s, index) => ({
+  const steps: SliderProps["customSteps"] = atLeastTwoSizes.map((s, index) => ({
     value: index,
     label: `${s.quota}`,
   }));
+
+  const valueIndex =
+    validity !== "trial"
+      ? atLeastTwoSizes.findIndex((size) => size.quota === value)
+      : -1;
 
   const helperText = (
     <FieldSizeHelperText
@@ -121,7 +125,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
           showTicks={true}
           customSteps={steps}
           className="pf-u-w-100"
-          isDisabled={isDisabled || validity === "trial"}
+          isDisabled={isDisabled || validity === "trial" || sizes.length === 1}
           onChange={handleChange}
           aria-describedby="streaming-size"
         />


### PR DESCRIPTION
**What this PR does / why we need it**:

Integrating the create Kafka instance with sizes with the new APIs, I realized that trial instances come with a single size. The slider wasn't working properly with a single size, this adds an extra scenario for that where the slider is rendered with a faux 0 size that can't be selected.

**Verification steps** 

Kafka > Create Kafka Instance With Size > Components > Field Size

![image](https://user-images.githubusercontent.com/966316/168258456-5c3b9e6f-297d-4653-9263-6b1a72389ea4.png)
