### PR TITLE
feat: support different sizes for standard and trial instances in the create Kafka dialog with sizes

### DIFF
--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
@@ -49,7 +49,12 @@ const CreateKafkaInstanceMachine = createMachine(
         selectedProvider: ProviderInfo | undefined;
 
         // based on the form.provider and form.region selection
-        sizes: Size[] | undefined;
+        sizes:
+          | {
+              standard: Size[];
+              trial: Size;
+            }
+          | undefined;
 
         creationError: CreateKafkaInstanceError | undefined;
       },
@@ -379,8 +384,13 @@ const CreateKafkaInstanceMachine = createMachine(
         };
       }),
       setSizes: assign((context, event) => {
-        const sizes: Size[] = [...event.data.sizes];
-        const smallestSize = sizes.sort((a, b) => a.quota - b.quota)[0];
+        const sizes: { standard: Size[]; trial: Size } = {
+          standard: event.data.standard,
+          trial: event.data.trial,
+        };
+        const smallestSize = sizes.standard.sort(
+          (a, b) => a.quota - b.quota
+        )[0];
         return {
           sizes,
           form: {
@@ -497,7 +507,8 @@ const CreateKafkaInstanceMachine = createMachine(
       noProviderAndRegion: ({ form }) =>
         form.provider === undefined || form.region === undefined,
       noSizes: ({ sizes }) => sizes === undefined,
-      emptySizes: ({ sizes }) => sizes !== undefined && sizes.length === 0,
+      emptySizes: ({ sizes }) =>
+        sizes !== undefined && sizes.standard.length === 0,
       sizeIsInQuota: ({ form, capabilities }) =>
         capabilities !== undefined &&
         form.size !== undefined &&

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceProvider.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceProvider.tsx
@@ -72,6 +72,9 @@ export function useCreateKafkaInstanceMachine() {
 
   const selector = useCallback(
     (state: typeof service.state) => {
+      const isTrial =
+        state.context.capabilities === undefined ||
+        state.context.capabilities.plan === "trial";
       const isFormInvalid = state.context.creationError === "form-invalid";
       const isNameTaken = state.context.creationError === "name-taken";
 
@@ -80,9 +83,11 @@ export function useCreateKafkaInstanceMachine() {
       const canCreate = state.matches("configuring");
       const isLoadingSizes = state.hasTag(SIZE_LOADING);
 
-      const selectedSize = state.context.sizes?.find(
-        (s) => state.context.form.size?.id === s.id
-      );
+      const selectedSize = isTrial
+        ? state.context.sizes?.trial
+        : state.context.sizes?.standard.find(
+            (s) => state.context.form.size?.id === s.id
+          );
 
       return {
         form: state.context.form,
@@ -107,9 +112,7 @@ export function useCreateKafkaInstanceMachine() {
         isProviderError: !state.hasTag(PROVIDER_VALID) && isFormInvalid,
         isRegionError: !state.hasTag(REGION_VALID) && isFormInvalid,
 
-        isTrial:
-          state.context.capabilities === undefined ||
-          state.context.capabilities.plan === "trial",
+        isTrial,
         isLoading,
         isLoadingSizes,
         isSaving,

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -192,7 +192,7 @@ export const ConnectedCreateKafkaInstanceWithSizes: VoidFunctionComponent<
           ) : (
             <InstanceInfo
               isTrial={isTrial}
-              trialDurationInHours={48}
+              trialDurationInHours={selectedSize.trialDurationHours}
               ingress={selectedSize.ingress}
               egress={selectedSize.egress}
               storage={selectedSize.storage}
@@ -327,7 +327,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
   return (
     <FieldSize
       value={form.size?.quota || 1}
-      sizes={isSizeAvailable ? sizes : undefined}
+      sizes={isSizeAvailable ? sizes?.standard : undefined}
       remainingQuota={capabilities?.remainingQuota || 0}
       isDisabled={!isFormEnabled || sizes === undefined}
       isLoading={isLoading || isLoadingSizes}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
@@ -18,7 +18,6 @@ import {
   Provider,
   ProviderInfo,
   Providers,
-  Size,
 } from "../types";
 
 export const AWS: ProviderInfo = {
@@ -50,76 +49,113 @@ export const AZURE: ProviderInfo = {
 
 export const PROVIDERS: Providers = [AWS, AZURE];
 
-const SIZES: { [key: string]: Size[] } = {
-  aws: [
-    {
-      id: "x1",
+const SIZES: { [key: string]: GetSizesData } = {
+  aws: {
+    standard: [
+      {
+        id: "x1",
+        displayName: "1",
+        quota: 1,
+        status: "stable",
+        ingress: 3,
+        egress: 31,
+        storage: 5,
+        connections: 6,
+        connectionRate: 7,
+        maxPartitions: 8,
+        messageSize: 9,
+        trialDurationHours: undefined,
+      },
+      {
+        id: "x2",
+        displayName: "2",
+        quota: 2,
+        status: "preview",
+        ingress: 30,
+        egress: 301,
+        storage: 50,
+        connections: 60,
+        connectionRate: 70,
+        maxPartitions: 80,
+        messageSize: 90,
+        trialDurationHours: undefined,
+      },
+      {
+        id: "x3",
+        displayName: "3",
+        quota: 5,
+        status: "preview",
+        ingress: 300,
+        egress: 3001,
+        storage: 500,
+        connections: 600,
+        connectionRate: 700,
+        maxPartitions: 800,
+        messageSize: 900,
+        trialDurationHours: undefined,
+      },
+    ],
+    trial: {
+      id: "trialx1",
       displayName: "1",
-      quota: 1,
+      quota: 0,
       status: "stable",
-      ingress: 3,
-      egress: 31,
-      storage: 5,
-      connections: 6,
-      connectionRate: 7,
-      maxPartitions: 8,
-      messageSize: 9,
+      ingress: 1,
+      egress: 1,
+      storage: 1,
+      connections: 1,
+      connectionRate: 1,
+      maxPartitions: 1,
+      messageSize: 1,
+      trialDurationHours: 48,
     },
-    {
-      id: "x2",
-      displayName: "2",
-      quota: 2,
-      status: "preview",
-      ingress: 30,
-      egress: 301,
-      storage: 50,
-      connections: 60,
-      connectionRate: 70,
-      maxPartitions: 80,
-      messageSize: 90,
-    },
-    {
-      id: "x3",
-      displayName: "3",
-      quota: 5,
-      status: "preview",
-      ingress: 300,
-      egress: 3001,
-      storage: 500,
-      connections: 600,
-      connectionRate: 700,
-      maxPartitions: 800,
-      messageSize: 900,
-    },
-  ],
-  azure: [
-    {
-      id: "x1",
+  },
+  azure: {
+    standard: [
+      {
+        id: "x1",
+        displayName: "1",
+        quota: 3,
+        status: "preview",
+        ingress: 3,
+        egress: 31,
+        storage: 5,
+        connections: 6,
+        connectionRate: 7,
+        maxPartitions: 8,
+        messageSize: 9,
+        trialDurationHours: undefined,
+      },
+      {
+        id: "x2",
+        displayName: "2",
+        quota: 9,
+        status: "preview",
+        ingress: 30,
+        egress: 301,
+        storage: 50,
+        connections: 60,
+        connectionRate: 70,
+        maxPartitions: 80,
+        messageSize: 90,
+        trialDurationHours: undefined,
+      },
+    ],
+    trial: {
+      id: "trialx1",
       displayName: "1",
-      quota: 3,
-      status: "preview",
-      ingress: 3,
-      egress: 31,
-      storage: 5,
-      connections: 6,
-      connectionRate: 7,
-      maxPartitions: 8,
-      messageSize: 9,
+      quota: 0,
+      status: "stable",
+      ingress: 1,
+      egress: 1,
+      storage: 1,
+      connections: 1,
+      connectionRate: 1,
+      maxPartitions: 1,
+      messageSize: 1,
+      trialDurationHours: 24,
     },
-    {
-      id: "x2",
-      displayName: "2",
-      quota: 9,
-      status: "preview",
-      ingress: 30,
-      egress: 301,
-      storage: 50,
-      connections: 60,
-      connectionRate: 70,
-      maxPartitions: 80,
-      messageSize: 90,
-    },
-  ],
+  },
 };
 
 export function makeAvailableProvidersAndDefaults(
@@ -336,14 +372,15 @@ export const Template: ComponentStory<typeof CreateKafkaInstanceWithSizes> = (
     return apiSizes === "normal"
       ? fakeApi<GetSizesData>(
           {
-            sizes: SIZES[provider],
+            ...SIZES[provider],
           },
           apiLatency
         )
       : apiSizes === "no-sizes"
       ? fakeApi<GetSizesData>(
           {
-            sizes: [],
+            standard: [],
+            trial: {},
           },
           apiLatency
         )

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfo.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfo.tsx
@@ -24,7 +24,7 @@ export type InstanceInfoProps = {
 };
 
 export type InstanceInfoLimitsProps = {
-  trialDurationInHours: number;
+  trialDurationInHours: number | undefined;
   ingress: number;
   egress: number;
   /**

--- a/src/Kafka/CreateKafkaInstanceWithSizes/types.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/types.ts
@@ -36,6 +36,7 @@ export type Size = {
   connectionRate: number;
   maxPartitions: number;
   messageSize: number;
+  trialDurationHours: number | undefined;
 };
 
 export type CreateKafkaInstanceError =
@@ -56,7 +57,8 @@ export type CreateKafkaInitializationData = {
 };
 
 export type GetSizesData = {
-  sizes: Size[];
+  standard: Size[];
+  trial: Size;
 };
 
 export type CreateKafkaFormData = {


### PR DESCRIPTION
**What this PR does / why we need it**:

[This addresses @jgiardino comment here:](https://github.com/redhat-developer/app-services-ui-components/pull/345#issuecomment-1128198906)

> This might be a bad design, but the [original design](https://docs.google.com/presentation/d/1U4j27K3L-9Ry0GPe-fcKoU48dCPlEJsfoXJUpldAY3U/edit#slide=id.g118b16caf36_0_0) was to accommodate this use case:
> 
> > If I don't have a subscription and can only create a trial instance, then I can get some idea about what options are available with a subscription.
> 
> In this use case, the size option isn't meant to show me what trial sizes are available, but rather what sizes are available with a subscription. This is why in the example above, we show that there are two options, 1 SU and 2 SU, along with a message that size options are only available when you have a subscription.
> 
> I realize that how we're trying to convey these options in the UI isn't a clean map to what the API gives us, and it would be good to refactor the UI to better reflect what we're getting from the API. But when we chatted with Bilgin last week, it sounded like we likely have half a year to refactor this UI. I also would like to better understand what the next evolution of trial instances are and any expectations regarding how we represent trial instances to the user before refactoring this UI.
> 
> For this upcoming release, I would suggest we keep what's currently implemented in [Quota Available - Trial](https://redhat-developer.github.io/app-services-ui-components/?path=/story/kafka-create-kafka-instance-with-sizes-stories-form-load--trial-available-on-form-load), since this matches the design as expected.
> 
> But also, we definitely should not use the concept of a streaming unit when describing a trial instance. When we do refactor the UI, we need to remove the mapping of sizes to a "streaming unit" and just display the `displayName` property of a size, and maybe not use a slider at all.

**Verification steps** 

Trial instances show the sizes available for standard instances in the slider, but the limits on the right pane are those for the trial instance.
![image](https://user-images.githubusercontent.com/966316/168789547-1458facb-40e2-48a4-85e5-4f47a09e0e79.png)

Standard instances still work as they should
![image](https://user-images.githubusercontent.com/966316/168790206-eb13f649-bb91-4039-abd0-8f005e41a702.png)

