### PR TITLE
fix: trial instances don't check for the correctness of the selected size since it can't be selected

### DIFF
--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.ts
@@ -508,10 +508,14 @@ const CreateKafkaInstanceMachine = createMachine(
       noSizes: ({ sizes }) => sizes === undefined,
       emptySizes: ({ sizes }) =>
         sizes !== undefined && sizes.standard.length === 0,
-      sizeIsInQuota: ({ form, capabilities }) =>
-        capabilities !== undefined &&
-        form.size !== undefined &&
-        form.size.quota <= capabilities.remainingQuota,
+      sizeIsInQuota: ({ form, capabilities }) => {
+        if (capabilities === undefined) return false;
+        if (capabilities.plan === "trial") return true;
+        return (
+          form.size !== undefined &&
+          form.size.quota <= capabilities.remainingQuota
+        );
+      },
       canCreateInstances: ({ capabilities }) =>
         capabilities !== undefined &&
         capabilities.plan !== undefined &&

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
@@ -358,7 +358,7 @@ export const Template: ComponentStory<typeof CreateKafkaInstanceWithSizes> = (
             instanceAvailability: apiScenario,
             defaultProvider: apiDefaultProvider,
             providers: apiProviders,
-            remainingQuota: apiRemainingQuota,
+            remainingQuota: apiPlan === "trial" ? 0 : apiRemainingQuota,
             maxStreamingUnits: apiMaxStreamingUnits,
           },
           providers,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug where the form would show an error alert asking to fix form errors when creating trial instances and with 0 as the available quota.
