### PR TITLE
fix: missing overviewpagev2

### DIFF
--- a/src/AppServices/index.ts
+++ b/src/AppServices/index.ts
@@ -1,4 +1,6 @@
 export * from "./APIManagementPage";
 export * from "./DataSciencePage";
-export * from "./OverviewPage";
 export * from "./KafkaPage";
+export * from "./KafkaPageV2";
+export * from "./OverviewPage";
+export * from "./OverviewPageV2";


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose OverviewPageV2 that is missing for some reason from the index file.