### PR TITLE
chore: make renovatebot open separate PRs for major releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,7 @@
       "groupName": "xstate"
     }
   ],
-  "ignoreDeps": ["@xstate/inspect"]
+  "ignoreDeps": ["@xstate/inspect"],
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Force renovatebot to open different PRs for major releases, to be able to disable some specific major while allowing others.