### PR TITLE
fix: metrics typo

### DIFF
--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -61,5 +61,5 @@
   "used_disk_space": "Used disk space",
   "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
   "metrics_lag_title": "Metrics experience lag",
-  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages."
+  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages."
 }

--- a/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
@@ -1,7 +1,7 @@
-import { render, waitForI18n } from "../../../test-utils";
-import { composeStories } from "@storybook/testing-react";
-import * as stories from "./MetricsLagAlert.stories";
 import { userEvent } from "@storybook/testing-library";
+import { composeStories } from "@storybook/testing-react";
+import { render, waitForI18n } from "../../../test-utils";
+import * as stories from "./MetricsLagAlert.stories";
 
 const { LagMessage } = composeStories(stories);
 
@@ -13,7 +13,7 @@ describe("Metric lag", () => {
     expect(await comp.findByText("Metrics experience lag")).toBeInTheDocument();
     expect(
       await comp.findByText(
-        "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages."
+        "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages."
       )
     ).toBeInTheDocument();
 
@@ -24,7 +24,7 @@ describe("Metric lag", () => {
     ).not.toBeInTheDocument();
     expect(
       await comp.queryByText(
-        "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages."
+        "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages."
       )
     ).not.toBeInTheDocument();
   });


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a missing space in the copy