### PR TITLE
fix: use trial duration from the API

### DIFF
--- a/locales/en/create-kafka-instance-with-sizes.json
+++ b/locales/en/create-kafka-instance-with-sizes.json
@@ -67,7 +67,7 @@
     "regions_unavailable_message": "Cloud provider regions are temporarily unavailable. Try again later.",
     "system_unavailable_message": "$t(common:unexpected_error)",
     "system_unavailable_title": "$t(common:something_went_wrong)",
-    "trial_available_message": "The trial has a duration of {{time}} hours. If you are interested in using this service in production, go to our <0>Streams for Apache Kafka Overview</0> page to see what options are available during creation and learn how to contact us.",
+    "trial_available_message": "The trial has a duration of <1>{{time}}</1> hours. If you are interested in using this service in production, go to our <0>Streams for Apache Kafka Overview</0> page to see what options are available during creation and learn how to contact us.",
     "trial_available_title": "You can create a trial instance to evaluate this service.",
     "trial_unavailable_message": "All available trial instances are currently in use. Try again later.",
     "trial_unavailable_title": "$t(common:kafka) instances are unavailable for creation",

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -159,6 +159,7 @@ export const ConnectedCreateKafkaInstanceWithSizes: VoidFunctionComponent<
         onClickKafkaOverview={onClickKafkaOverview}
         maxStreamingUnits={capabilities?.maxStreamingUnits}
         onClickContactUs={onClickContactUs}
+        trialDurationInHours={selectedSize?.trialDurationHours}
       />
 
       <Flex

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormLoad.test.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormLoad.test.tsx
@@ -173,7 +173,7 @@ describe("CreateKafkaInstanceWithSizes", () => {
     );
 
     expect(
-      await comp.queryByText("The trial has a duration of 48 hours.", {
+      await comp.findByText("The trial has a duration of 48 hours.", {
         exact: false,
       })
     ).toBeInTheDocument();

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/ModalAlerts.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/ModalAlerts.tsx
@@ -169,8 +169,11 @@ export const ModalAlerts: VoidFunctionComponent<ModalAlertsProps> = ({
                       onClick={onClickKafkaOverview}
                       isInline
                     />,
+                    trialDurationInHours ? <></> : <Spinner size={"sm"} />,
                   ]}
-                  values={{ time: trialDurationInHours }}
+                  values={{
+                    time: trialDurationInHours,
+                  }}
                 />
               </Alert>
             );

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/ModalAlerts.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/ModalAlerts.tsx
@@ -18,6 +18,7 @@ export type ModalAlertsProps = {
   onClickKafkaOverview: () => void;
   onClickContactUs: () => void;
   maxStreamingUnits: number | undefined;
+  trialDurationInHours: number | undefined;
 };
 
 export const ModalAlerts: VoidFunctionComponent<ModalAlertsProps> = ({
@@ -28,6 +29,7 @@ export const ModalAlerts: VoidFunctionComponent<ModalAlertsProps> = ({
   onClickKafkaOverview,
   onClickContactUs,
   maxStreamingUnits,
+  trialDurationInHours,
 }) => {
   const { t } = useTranslation("create-kafka-instance-with-sizes");
 
@@ -168,7 +170,7 @@ export const ModalAlerts: VoidFunctionComponent<ModalAlertsProps> = ({
                       isInline
                     />,
                   ]}
-                  values={{ time: 48 }}
+                  values={{ time: trialDurationInHours }}
                 />
               </Alert>
             );


### PR DESCRIPTION
**What this PR does / why we need it**:
Add dynamic duration (lifespan_seconds) instead hard code 48 hours

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/MGDSTRM-7914

**Verification steps** 

- User trial kafka and open create kafka modal 
- There is a expiration time duration which is based on api field `lifespan_seconds`


![image](https://user-images.githubusercontent.com/11775081/170463709-13c24677-2c10-4123-9bbd-ac06871923f1.png)


**Is there any work left / what's next** :
Rest part adding duration in table that will be covered in kas-ui in separate PR.
https://github.com/bf2fc6cc711aee1a0c2a/kas-ui/pull/1181

**Special notes for your reviewer**:
