### PR TITLE
fix: improve create Kafka dialog UX

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,5 +1,5 @@
 <style>
   #panel-tab-content > div {
-      height: 100%;
+    height: 100%;
   }
 </style>

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,5 @@
+<style>
+  #panel-tab-content > div {
+      height: 100%;
+  }
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -19,9 +19,7 @@ try {
 } catch (e) {}
 
 export const parameters: Parameters = {
-  xstate: {
-    height: "1000px",
-  },
+  xstate: {},
   xstateInspectOptions: {
     url: "https://stately.ai/viz?inspect",
     serialize: null,

--- a/locales/en/create-kafka-instance-with-sizes.json
+++ b/locales/en/create-kafka-instance-with-sizes.json
@@ -86,6 +86,8 @@
   "size_help_content": "Size of a $t(common:kafka) instance is based on streaming units. The number of streaming units defines the capacity, resources, and limits of an instance. An instance with a larger size can handle higher loads and process larger amounts of events, has more storage, and can handle more clients and connections.",
   "size_preview_message": "The selected size is available as a Technology Preview with limited capabilities at this time. To learn more, refer to the Workload Balancing section of the <0>Service Definition</0> page.",
   "size_preview_title": "Technology Preview",
+  "size_unavailable_message": "Try a different selection or try again later",
+  "size_unavailable_title": "The selected size is temporarily unavailable in the selected cloud region",
   "sizes_error": "$t(common:something_went_wrong) while fetching the available sizes. Select another cloud provider or cloud region, or try again later.",
   "sizes_missing": "Size options display when a cloud provider and region are selected",
   "some_region_unavailable_helper_text": "One or more regions in the selected cloud provider are temporarily unavailable. Select an available region or try again later.",

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -34,6 +34,8 @@
   "metric_kpi_topics_description": "Topics are event logs in a $t(common:kafka) instance. This metric shows the total number of topics in the $t(common:kafka) instance.",
   "metric_kpi_topics_name": "Topics",
   "metric_not_available": "Data unavailable",
+  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages.",
+  "metrics_lag_title": "Metrics experience lag",
   "outgoing_bytes": "Outgoing bytes ({{topic}})",
   "outgoing_bytes_all_topics": "Outgoing bytes (all topics)",
   "partition_limit": "Limit {{topic}} partitions",

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -34,7 +34,7 @@
   "metric_kpi_topics_description": "Topics are event logs in a $t(common:kafka) instance. This metric shows the total number of topics in the $t(common:kafka) instance.",
   "metric_kpi_topics_name": "Topics",
   "metric_not_available": "Data unavailable",
-  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh.This might result in metrics appearing out-of-sync and with details displayed on other pages.",
+  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages.",
   "metrics_lag_title": "Metrics experience lag",
   "outgoing_bytes": "Outgoing bytes ({{topic}})",
   "outgoing_bytes_all_topics": "Outgoing bytes (all topics)",
@@ -61,7 +61,5 @@
   "total_bytes": "Bytes incoming and outgoing",
   "total_bytes_popover_header": "Bytes incoming and outgoing",
   "used_disk_space": "Used disk space",
-  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
-  "metrics_lag_title": "Metrics experience lag",
-  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages."
+  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed."
 }

--- a/locales/en/metrics.json
+++ b/locales/en/metrics.json
@@ -34,7 +34,7 @@
   "metric_kpi_topics_description": "Topics are event logs in a $t(common:kafka) instance. This metric shows the total number of topics in the $t(common:kafka) instance.",
   "metric_kpi_topics_name": "Topics",
   "metric_not_available": "Data unavailable",
-  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages.",
+  "metrics_lag_description": "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync with details displayed on other pages.",
   "metrics_lag_title": "Metrics experience lag",
   "outgoing_bytes": "Outgoing bytes ({{topic}})",
   "outgoing_bytes_all_topics": "Outgoing bytes (all topics)",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,14 +1,14 @@
-import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
-import typescript from "rollup-plugin-typescript2";
-import { terser } from "rollup-plugin-terser";
-import autoExternals from "rollup-plugin-auto-external";
-import renameNodeModules from "rollup-plugin-rename-node-modules";
-import postcss from "rollup-plugin-postcss";
-import replace from "@rollup/plugin-replace";
 import json from "@rollup/plugin-json";
+import resolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
 import { importMetaAssets } from "@web/rollup-plugin-import-meta-assets";
 import path from "path";
+import autoExternals from "rollup-plugin-auto-external";
+import postcss from "rollup-plugin-postcss";
+import renameNodeModules from "rollup-plugin-rename-node-modules";
+import { terser } from "rollup-plugin-terser";
+import typescript from "rollup-plugin-typescript2";
 
 import packageJson from "./package.json";
 
@@ -33,6 +33,14 @@ export default {
       preserveModulesRoot: "src",
     },
   ],
+  external: [
+    "react/jsx-runtime",
+    "@patternfly/react-icons/dist/js/icons/external-link-alt-icon",
+    "@patternfly/react-icons/dist/js/icons/search-icon",
+    "@patternfly/react-icons/dist/js/icons/help-icon",
+    "@patternfly/react-icons/dist/js/icons/outlined-clock-icon",
+    "@patternfly/react-icons/dist/js/icons/check-circle-icon",
+  ],
   plugins: [
     autoExternals(),
     renameNodeModules("external"),
@@ -53,4 +61,8 @@ export default {
     importMetaAssets(),
     terser(),
   ],
+  onwarn: (warning: Error) => {
+    // better fail on warnings
+    throw new Error("Warning as error: " + warning.message);
+  },
 };

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -61,7 +61,7 @@ export default {
     importMetaAssets(),
     terser(),
   ],
-  onwarn: (warning: Error) => {
+  onwarn: (warning) => {
     // better fail on warnings
     throw new Error("Warning as error: " + warning.message);
   },

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.typegen.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceMachine.typegen.ts
@@ -4,19 +4,18 @@ export interface Typegen0 {
   "@@xstate/typegen": true;
   eventsCausingActions: {
     setAvailableProvidersAndDefault: "done.invoke.createKafkaInstance.loading:invocation[0]";
-    resetCreationErrorMessage: "formChange" | "";
+    initDone: "done.invoke.createKafkaInstance.loading:invocation[0]";
     setName: "nameChange";
-    fieldChange:
-      | "nameChange"
-      | "providerChange"
-      | "regionChange"
-      | "sizeChange";
+    formChange: "nameChange" | "providerChange" | "regionChange" | "sizeChange";
     setProvider: "providerChange";
     setRegion: "regionChange";
     setSize: "sizeChange";
-    setSizes: "done.invoke.createKafkaInstance.configuring.size.loading:invocation[0]";
+    setSizes:
+      | "done.invoke.createKafkaInstance.standardPlan.configuring.size.loading:invocation[0]"
+      | "done.invoke.createKafkaInstance.trialPlan.configuring.size.loading:invocation[0]";
+    formSubmit: "create";
+    resetCreationErrorMessage: "formChange" | "create";
     setCreationError: "createError";
-    markRequiredFields: "";
   };
   internalEvents: {
     "done.invoke.createKafkaInstance.loading:invocation[0]": {
@@ -24,18 +23,27 @@ export interface Typegen0 {
       data: unknown;
       __tip: "See the XState TS docs to learn how to strongly type this.";
     };
-    "": { type: "" };
-    "done.invoke.createKafkaInstance.configuring.size.loading:invocation[0]": {
-      type: "done.invoke.createKafkaInstance.configuring.size.loading:invocation[0]";
+    "done.invoke.createKafkaInstance.standardPlan.configuring.size.loading:invocation[0]": {
+      type: "done.invoke.createKafkaInstance.standardPlan.configuring.size.loading:invocation[0]";
       data: unknown;
       __tip: "See the XState TS docs to learn how to strongly type this.";
     };
+    "done.invoke.createKafkaInstance.trialPlan.configuring.size.loading:invocation[0]": {
+      type: "done.invoke.createKafkaInstance.trialPlan.configuring.size.loading:invocation[0]";
+      data: unknown;
+      __tip: "See the XState TS docs to learn how to strongly type this.";
+    };
+    "": { type: "" };
     "xstate.init": { type: "xstate.init" };
   };
   invokeSrcNameMap: {
     getAvailableProvidersAndDefaults: "done.invoke.createKafkaInstance.loading:invocation[0]";
-    getSizes: "done.invoke.createKafkaInstance.configuring.size.loading:invocation[0]";
-    createInstance: "done.invoke.createKafkaInstance.saving:invocation[0]";
+    getSizes:
+      | "done.invoke.createKafkaInstance.standardPlan.configuring.size.loading:invocation[0]"
+      | "done.invoke.createKafkaInstance.trialPlan.configuring.size.loading:invocation[0]";
+    createInstance:
+      | "done.invoke.createKafkaInstance.standardPlan.configuring.form.saving:invocation[0]"
+      | "done.invoke.createKafkaInstance.trialPlan.configuring.form.saving:invocation[0]";
   };
   missingImplementations: {
     actions: never;
@@ -49,96 +57,173 @@ export interface Typegen0 {
   eventsCausingServices: {
     getAvailableProvidersAndDefaults: "xstate.init";
     getSizes: "";
-    createInstance: "";
+    createInstance: "create";
   };
   eventsCausingGuards: {
+    canCreateStandardInstances: "";
+    canCreateTrialInstances: "";
     isOverQuota: "";
-    isTrialUsed: "";
     isInstanceUnavailable: "";
     isRegionsUnavailable: "";
-    isTrialUnavailable: "";
-    canCreateInstances: "";
-    canSave: "formChange" | "";
-    nameIsUntouched: "";
     nameIsEmpty: "";
     nameIsValid: "";
-    providerIsUntouched: "";
+    didProviderChange: "providerChange";
     providerIsValid: "";
-    regionIsUntouched: "";
+    didRegionChange: "regionChange";
     regionIsValid: "";
+    didSizeChange: "sizeChange";
     noProviderAndRegion: "";
     noSizes: "";
     emptySizes: "";
-    sizeIsInQuota: "";
+    sizeIsDisabled: "";
+    sizeIsOverQuota: "";
+    canSave: "create" | "formChange";
+    isTrialUsed: "";
+    isTrialUnavailable: "";
   };
   eventsCausingDelays: {};
   matchesStates:
     | "loading"
     | "systemUnavailable"
-    | "verifyAvailability"
-    | "cantCreate"
-    | "cantCreate.unknown-error"
-    | "cantCreate.over-quota"
-    | "cantCreate.trial-used"
-    | "cantCreate.instance-unavailable"
-    | "cantCreate.regions-unavailable"
-    | "cantCreate.trial-unavailable"
-    | "configuring"
-    | "configuring.name"
-    | "configuring.name.untouched"
-    | "configuring.name.empty"
-    | "configuring.name.invalid"
-    | "configuring.name.valid"
-    | "configuring.name.validate"
-    | "configuring.provider"
-    | "configuring.provider.untouched"
-    | "configuring.provider.validate"
-    | "configuring.provider.invalid"
-    | "configuring.provider.valid"
-    | "configuring.region"
-    | "configuring.region.untouched"
-    | "configuring.region.validate"
-    | "configuring.region.invalid"
-    | "configuring.region.valid"
-    | "configuring.size"
-    | "configuring.size.validate"
-    | "configuring.size.idle"
-    | "configuring.size.overQuota"
-    | "configuring.size.valid"
-    | "configuring.size.error"
-    | "configuring.size.loading"
-    | "submit"
-    | "formInvalid"
-    | "saving"
+    | "selectPlan"
+    | "standardPlan"
+    | "standardPlan.verifyAvailability"
+    | "standardPlan.overQuota"
+    | "standardPlan.instanceUnavailable"
+    | "standardPlan.regionsUnavailable"
+    | "standardPlan.configuring"
+    | "standardPlan.configuring.name"
+    | "standardPlan.configuring.name.untouched"
+    | "standardPlan.configuring.name.empty"
+    | "standardPlan.configuring.name.invalid"
+    | "standardPlan.configuring.name.valid"
+    | "standardPlan.configuring.name.validate"
+    | "standardPlan.configuring.provider"
+    | "standardPlan.configuring.provider.untouched"
+    | "standardPlan.configuring.provider.validate"
+    | "standardPlan.configuring.provider.invalid"
+    | "standardPlan.configuring.provider.valid"
+    | "standardPlan.configuring.region"
+    | "standardPlan.configuring.region.untouched"
+    | "standardPlan.configuring.region.validate"
+    | "standardPlan.configuring.region.invalid"
+    | "standardPlan.configuring.region.valid"
+    | "standardPlan.configuring.size"
+    | "standardPlan.configuring.size.validate"
+    | "standardPlan.configuring.size.idle"
+    | "standardPlan.configuring.size.disabled"
+    | "standardPlan.configuring.size.overQuota"
+    | "standardPlan.configuring.size.valid"
+    | "standardPlan.configuring.size.error"
+    | "standardPlan.configuring.size.loading"
+    | "standardPlan.configuring.form"
+    | "standardPlan.configuring.form.unsubmitted"
+    | "standardPlan.configuring.form.invalid"
+    | "standardPlan.configuring.form.saving"
+    | "trialPlan"
+    | "trialPlan.verifyAvailability"
+    | "trialPlan.trialUsed"
+    | "trialPlan.trialUnavailable"
+    | "trialPlan.configuring"
+    | "trialPlan.configuring.name"
+    | "trialPlan.configuring.name.untouched"
+    | "trialPlan.configuring.name.empty"
+    | "trialPlan.configuring.name.invalid"
+    | "trialPlan.configuring.name.valid"
+    | "trialPlan.configuring.name.validate"
+    | "trialPlan.configuring.provider"
+    | "trialPlan.configuring.provider.untouched"
+    | "trialPlan.configuring.provider.validate"
+    | "trialPlan.configuring.provider.invalid"
+    | "trialPlan.configuring.provider.valid"
+    | "trialPlan.configuring.region"
+    | "trialPlan.configuring.region.untouched"
+    | "trialPlan.configuring.region.validate"
+    | "trialPlan.configuring.region.invalid"
+    | "trialPlan.configuring.region.valid"
+    | "trialPlan.configuring.form"
+    | "trialPlan.configuring.form.unsubmitted"
+    | "trialPlan.configuring.form.invalid"
+    | "trialPlan.configuring.form.saving"
+    | "trialPlan.configuring.size"
+    | "trialPlan.configuring.size.validate"
+    | "trialPlan.configuring.size.idle"
+    | "trialPlan.configuring.size.disabled"
+    | "trialPlan.configuring.size.overQuota"
+    | "trialPlan.configuring.size.valid"
+    | "trialPlan.configuring.size.error"
+    | "trialPlan.configuring.size.loading"
     | "complete"
     | {
-        cantCreate?:
-          | "unknown-error"
-          | "over-quota"
-          | "trial-used"
-          | "instance-unavailable"
-          | "regions-unavailable"
-          | "trial-unavailable";
-        configuring?:
-          | "name"
-          | "provider"
-          | "region"
-          | "size"
+        standardPlan?:
+          | "verifyAvailability"
+          | "overQuota"
+          | "instanceUnavailable"
+          | "regionsUnavailable"
+          | "configuring"
           | {
-              name?: "untouched" | "empty" | "invalid" | "valid" | "validate";
-              provider?: "untouched" | "validate" | "invalid" | "valid";
-              region?: "untouched" | "validate" | "invalid" | "valid";
-              size?:
-                | "validate"
-                | "idle"
-                | "overQuota"
-                | "valid"
-                | "error"
-                | "loading";
+              configuring?:
+                | "name"
+                | "provider"
+                | "region"
+                | "size"
+                | "form"
+                | {
+                    name?:
+                      | "untouched"
+                      | "empty"
+                      | "invalid"
+                      | "valid"
+                      | "validate";
+                    provider?: "untouched" | "validate" | "invalid" | "valid";
+                    region?: "untouched" | "validate" | "invalid" | "valid";
+                    size?:
+                      | "validate"
+                      | "idle"
+                      | "disabled"
+                      | "overQuota"
+                      | "valid"
+                      | "error"
+                      | "loading";
+                    form?: "unsubmitted" | "invalid" | "saving";
+                  };
+            };
+        trialPlan?:
+          | "verifyAvailability"
+          | "trialUsed"
+          | "trialUnavailable"
+          | "configuring"
+          | {
+              configuring?:
+                | "name"
+                | "provider"
+                | "region"
+                | "form"
+                | "size"
+                | {
+                    name?:
+                      | "untouched"
+                      | "empty"
+                      | "invalid"
+                      | "valid"
+                      | "validate";
+                    provider?: "untouched" | "validate" | "invalid" | "valid";
+                    region?: "untouched" | "validate" | "invalid" | "valid";
+                    form?: "unsubmitted" | "invalid" | "saving";
+                    size?:
+                      | "validate"
+                      | "idle"
+                      | "disabled"
+                      | "overQuota"
+                      | "valid"
+                      | "error"
+                      | "loading";
+                  };
             };
       };
   tags:
     | "systemUnavailable"
+    | "configurable"
     | "nameUntouched"
     | "nameEmpty"
     | "nameInvalid"
@@ -150,8 +235,12 @@ export interface Typegen0 {
     | "regionInvalid"
     | "regionValid"
     | "sizeIdle"
+    | "sizeDisabled"
     | "sizeOverQuota"
     | "sizeValid"
     | "sizeError"
-    | "sizeLoading";
+    | "sizeLoading"
+    | "formUnsubmitted"
+    | "formInvalid"
+    | "formSaving";
 }

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceProvider.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceProvider.tsx
@@ -18,6 +18,7 @@ import {
   SIZE_IDLE,
   SIZE_LOADING,
   SIZE_OVER_QUOTA,
+  SIZE_VALID,
   SYSTEM_UNAVAILABLE,
 } from "./CreateKafkaInstanceMachine";
 import {
@@ -114,8 +115,9 @@ export function useCreateKafkaInstanceMachine() {
         isNameTaken,
         isSizeDisabled: state.hasTag(SIZE_DISABLED),
         isSizeOverQuota: state.hasTag(SIZE_OVER_QUOTA),
-        isSizeError: state.hasTag(SIZE_ERROR),
+        isSizeLoadingError: state.hasTag(SIZE_ERROR),
         isSizeAvailable: !state.hasTag(SIZE_IDLE),
+        isSizeError: !state.hasTag(SIZE_VALID) && isFormInvalid,
 
         isProviderError: !state.hasTag(PROVIDER_VALID) && isFormInvalid,
         isRegionError: !state.hasTag(REGION_VALID) && isFormInvalid,

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -323,6 +323,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
     isSizeOverQuota,
     isSizeDisabled,
     isSizeError,
+    isSizeLoadingError,
     isFormEnabled,
     isLoadingSizes,
     isLoading,
@@ -338,6 +339,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
       isDisabled={!isFormEnabled || sizes === undefined}
       isLoading={isLoading || isLoadingSizes}
       isError={isSizeError}
+      isLoadingError={isSizeLoadingError}
       validity={
         isTrial
           ? "trial"

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -127,6 +127,7 @@ export const ConnectedCreateKafkaInstanceWithSizes: VoidFunctionComponent<
       ouiaId="modal-create-kafka"
       onClose={onCancel}
       appendTo={appendTo}
+      position="top"
       actions={[
         <Button
           key="submit"
@@ -189,7 +190,10 @@ export const ConnectedCreateKafkaInstanceWithSizes: VoidFunctionComponent<
           className="mas--CreateKafkaInstanceWithSizes__sidebar"
         >
           {isLoadingSizes || selectedSize === undefined ? (
-            <InstanceInfoSkeleton onClickQuickStart={onClickQuickStart} />
+            <InstanceInfoSkeleton
+              isTrial={isTrial}
+              onClickQuickStart={onClickQuickStart}
+            />
           ) : (
             <InstanceInfo
               isTrial={isTrial}
@@ -317,6 +321,7 @@ export const ConnectedFieldSize: VoidFunctionComponent<
     sizes,
     isSizeAvailable,
     isSizeOverQuota,
+    isSizeDisabled,
     isSizeError,
     isFormEnabled,
     isLoadingSizes,
@@ -333,7 +338,15 @@ export const ConnectedFieldSize: VoidFunctionComponent<
       isDisabled={!isFormEnabled || sizes === undefined}
       isLoading={isLoading || isLoadingSizes}
       isError={isSizeError}
-      validity={isTrial ? "trial" : isSizeOverQuota ? "over-quota" : "valid"}
+      validity={
+        isTrial
+          ? "trial"
+          : isSizeOverQuota
+          ? "over-quota"
+          : isSizeDisabled
+          ? "required"
+          : "valid"
+      }
       onChange={setSize}
       onLearnHowToAddStreamingUnits={onLearnHowToAddStreamingUnits}
       onLearnMoreAboutSizes={onLearnMoreAboutSizes}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/CreateKafkaInstanceWithSizes.tsx
@@ -270,6 +270,7 @@ export const ConnectedFieldCloudRegion: VoidFunctionComponent = () => {
   const {
     form,
     selectedProvider,
+    selectedSize,
     isRegionError,
     isFormEnabled,
     capabilities,
@@ -290,6 +291,7 @@ export const ConnectedFieldCloudRegion: VoidFunctionComponent = () => {
       regions={selectedProvider?.regions}
       value={form.region}
       isDisabled={!isFormEnabled}
+      isSizeUnavailable={selectedSize?.isDisabled || false}
       onChange={setRegion}
     />
   );

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormLoad.test.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormLoad.test.tsx
@@ -241,7 +241,7 @@ describe("CreateKafkaInstanceWithSizes", () => {
 
     expect(
       await comp.queryByText(
-        "Cloud provider regions are temporarily unavailable. Try again later.",
+        "All available trial instances are currently in use. Try again later.",
         { exact: false }
       )
     ).toBeInTheDocument();

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormSubmit.test.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/FormSubmit.test.tsx
@@ -20,7 +20,7 @@ describe("CreateKafkaInstanceWithSizes", () => {
     });
 
     expect(
-      await comp.queryByText(
+      await comp.findByText(
         "The selected size requires more streaming units. Your organization has 3 of 5 streaming units remaining. To deploy a new instance, reduce its size, delete an existing one first",
         { exact: false }
       )

--- a/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/Stories/storiesHelpers.tsx
@@ -24,10 +24,11 @@ export const AWS: ProviderInfo = {
   id: "aws",
   displayName: "Amazon Web Services",
   regions: [
-    { id: "eu-west-1", displayName: "EU, Ireland" },
+    { id: "eu-west-1", displayName: "EU, Ireland", isDisabled: false },
     {
       id: "us-east-1",
       displayName: "US East, N. Virginia",
+      isDisabled: false,
     },
   ],
 };
@@ -39,10 +40,12 @@ export const AZURE: ProviderInfo = {
     {
       id: "australiaeast",
       displayName: "Australia East",
+      isDisabled: false,
     },
     {
       id: "europenorth",
       displayName: "Europe North",
+      isDisabled: false,
     },
   ],
 };
@@ -65,6 +68,7 @@ const SIZES: { [key: string]: GetSizesData } = {
         maxPartitions: 8,
         messageSize: 9,
         trialDurationHours: undefined,
+        isDisabled: false,
       },
       {
         id: "x2",
@@ -79,10 +83,26 @@ const SIZES: { [key: string]: GetSizesData } = {
         maxPartitions: 80,
         messageSize: 90,
         trialDurationHours: undefined,
+        isDisabled: false,
       },
       {
         id: "x3",
         displayName: "3",
+        quota: 3,
+        status: "preview",
+        ingress: 300,
+        egress: 3001,
+        storage: 500,
+        connections: 600,
+        connectionRate: 700,
+        maxPartitions: 800,
+        messageSize: 900,
+        trialDurationHours: undefined,
+        isDisabled: true,
+      },
+      {
+        id: "x5",
+        displayName: "5",
         quota: 5,
         status: "preview",
         ingress: 300,
@@ -93,6 +113,7 @@ const SIZES: { [key: string]: GetSizesData } = {
         maxPartitions: 800,
         messageSize: 900,
         trialDurationHours: undefined,
+        isDisabled: false,
       },
     ],
     trial: {
@@ -108,6 +129,7 @@ const SIZES: { [key: string]: GetSizesData } = {
       maxPartitions: 1,
       messageSize: 1,
       trialDurationHours: 48,
+      isDisabled: false,
     },
   },
   azure: {
@@ -125,6 +147,7 @@ const SIZES: { [key: string]: GetSizesData } = {
         maxPartitions: 8,
         messageSize: 9,
         trialDurationHours: undefined,
+        isDisabled: false,
       },
       {
         id: "x2",
@@ -139,6 +162,7 @@ const SIZES: { [key: string]: GetSizesData } = {
         maxPartitions: 80,
         messageSize: 90,
         trialDurationHours: undefined,
+        isDisabled: false,
       },
     ],
     trial: {
@@ -154,6 +178,7 @@ const SIZES: { [key: string]: GetSizesData } = {
       maxPartitions: 1,
       messageSize: 1,
       trialDurationHours: 24,
+      isDisabled: false,
     },
   },
 };
@@ -453,9 +478,8 @@ export const sampleSubmit: PlayFunction<
   await userEvent.click(regionSelect);
   await userEvent.click(await canvas.findByText("US East, N. Virginia"));
 
-  await waitFor(() =>
-    expect(canvas.getByTestId("size-slider")).toBeInTheDocument()
-  );
+  expect(await canvas.findByTestId("size-slider")).not.toBeNull();
+
   await userEvent.click(
     await canvas.findByTestId("modalCreateKafka-buttonSubmit")
   );

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/CloudRegionsSelect.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/CloudRegionsSelect.tsx
@@ -12,6 +12,7 @@ export type CloudRegionProps = {
   value: Region | undefined;
   regions: RegionInfo[] | undefined;
   isDisabled: boolean;
+  isSizeUnavailable: boolean;
   onChange: (region: string) => void;
   validated?: SelectProps["validated"];
   placeholderText: SelectProps["placeholderText"];
@@ -21,6 +22,7 @@ export const CloudRegionSelect: FunctionComponent<CloudRegionProps> = ({
   value,
   regions,
   isDisabled,
+  isSizeUnavailable,
   validated,
   onChange,
   placeholderText,
@@ -67,7 +69,11 @@ export const CloudRegionSelect: FunctionComponent<CloudRegionProps> = ({
       selections={value}
       isOpen={isOpen}
       isDisabled={isDisabled}
-      aria-labelledby="form-cloud-region-option"
+      aria-describedby={
+        isSizeUnavailable
+          ? "instance-size-unavailable"
+          : "form-cloud-region-option"
+      }
       placeholderText={placeholderText}
     >
       {makeRegionOptions}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldCloudRegion.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldCloudRegion.stories.tsx
@@ -8,6 +8,7 @@ export default {
   component: FieldCloudRegionComp,
   args: {
     validity: "valid",
+    isSizeUnavailable: false,
     regions: PROVIDERS[0].regions,
   },
 } as ComponentMeta<typeof FieldCloudRegionComp>;

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldCloudRegion.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldCloudRegion.tsx
@@ -11,6 +11,7 @@ export const FieldCloudRegion: VoidFunctionComponent<FieldCloudRegionProps> = ({
   regions,
   onChange,
   isDisabled,
+  isSizeUnavailable,
   validity,
 }) => {
   const { t } = useTranslation("create-kafka-instance-with-sizes");
@@ -80,6 +81,7 @@ export const FieldCloudRegion: VoidFunctionComponent<FieldCloudRegionProps> = ({
         regions={regions}
         onChange={onChange}
         isDisabled={disableControl}
+        isSizeUnavailable={isSizeUnavailable}
         validated={validation}
         placeholderText={placeholder}
       />

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.stories.tsx
@@ -12,6 +12,26 @@ const sizes = [
   { id: "x5", displayName: "5", status: "preview", quota: 15 },
 ] as Size[];
 
+const sizesWithDisabled = [
+  { id: "x1", displayName: "1", status: "stable", quota: 1 },
+  { id: "x2", displayName: "2", status: "preview", quota: 3, isDisabled: true },
+  { id: "x3", displayName: "3", status: "preview", quota: 5, isDisabled: true },
+  {
+    id: "x4",
+    displayName: "4",
+    status: "preview",
+    quota: 10,
+    isDisabled: true,
+  },
+  {
+    id: "x5",
+    displayName: "5",
+    status: "preview",
+    quota: 15,
+    isDisabled: true,
+  },
+] as Size[];
+
 const summitSizes = [
   { id: "x1", displayName: "1", status: "stable", quota: 1 },
   { id: "x2", displayName: "2", status: "preview", quota: 2 },
@@ -45,6 +65,13 @@ export const Default = Template.bind({});
 export const TechPreview = Template.bind({});
 TechPreview.args = {
   value: 3,
+};
+
+export const SomeSizeDisabled = Template.bind({});
+SomeSizeDisabled.args = {
+  value: 3,
+  sizes: sizesWithDisabled,
+  validity: "required",
 };
 
 export const NoSizes = Template.bind({});

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
@@ -20,7 +20,8 @@ export type FieldSizeProps = {
   isDisabled: boolean;
   isLoading: boolean;
   isError: boolean;
-  validity: "valid" | "required" | "over-quota" | "trial";
+  isLoadingError: boolean;
+  validity: "valid" | "required" | "over-quota" | "trial" | "disabled";
   onChange: (size: Size) => void;
   onLearnHowToAddStreamingUnits: () => void;
   onLearnMoreAboutSizes: () => void;
@@ -32,6 +33,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
   isDisabled,
   isLoading,
   isError,
+  isLoadingError,
   validity,
   onChange,
   onLearnHowToAddStreamingUnits,
@@ -45,7 +47,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
     <FieldSizeHelperTextTrial onClick={onLearnMoreAboutSizes} />
   );
 
-  if (isLoading || isError) {
+  if (isLoading || isLoadingError) {
     return (
       <FormGroupWithPopover
         labelHead={t("common:size")}
@@ -64,7 +66,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
             </GridItem>
           </Grid>
         }
-        validated={isError ? "error" : "default"}
+        validated={isLoadingError ? "error" : "default"}
         helperTextInvalid={t("sizes_error")}
       />
     );
@@ -99,6 +101,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       remainingQuota={remainingQuota}
       isPreview={sizes[valueIndex]?.status === "preview"}
       isUnavailable={sizes[valueIndex]?.isDisabled}
+      isError={isError}
     />
   );
   const helperTextOverQuota = (
@@ -115,7 +118,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
   const validation =
     (validity !== "valid" || remainingQuota < value) &&
     validity !== "trial" &&
-    validity !== "required"
+    isError
       ? "error"
       : "default";
 

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
@@ -96,11 +96,13 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
     label: `${s.quota}`,
   }));
 
+  const isUnavailable = sizes[valueIndex]?.isDisabled;
+
   const helperText = (
     <FieldSizeHelperText
       remainingQuota={remainingQuota}
       isPreview={sizes[valueIndex]?.status === "preview"}
-      isUnavailable={sizes[valueIndex]?.isDisabled}
+      isUnavailable={isUnavailable}
       isError={isError}
     />
   );
@@ -146,7 +148,9 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
           className="pf-u-w-100"
           isDisabled={isDisabled || validity === "trial"}
           onChange={handleChange}
-          aria-describedby="streaming-size"
+          aria-describedby={
+            isUnavailable ? "instance-size-unavailable" : "streaming-size"
+          }
         />
         <span
           className="pf-c-input-group__text pf-m-plain pf-u-text-nowrap"

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSize.tsx
@@ -1,4 +1,10 @@
-import { Skeleton, Slider, SliderProps } from "@patternfly/react-core";
+import {
+  Grid,
+  GridItem,
+  Skeleton,
+  Slider,
+  SliderProps,
+} from "@patternfly/react-core";
 import { VoidFunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroupWithPopover } from "../../../shared";
@@ -48,7 +54,16 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
         labelBody={t("size_help_content")}
         buttonAriaLabel={t("size_field_aria")}
         isRequired={isRequired}
-        helperText={<Skeleton width={"50%"} />}
+        helperText={
+          <Grid sm={6} lg={12} hasGutter data-testid={"size-loading"}>
+            <GridItem>
+              <Skeleton width={"50%"} fontSize={"3xl"} />
+            </GridItem>
+            <GridItem>
+              <Skeleton width={"40%"} fontSize={"sm"} />
+            </GridItem>
+          </Grid>
+        }
         validated={isError ? "error" : "default"}
         helperTextInvalid={t("sizes_error")}
       />
@@ -65,7 +80,9 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
         buttonAriaLabel={t("size_field_aria")}
         isRequired={isRequired}
         helperText={validity === "trial" ? helperTextTrial : t("sizes_missing")}
-      />
+      >
+        <div data-testid={"size-slider"} />
+      </FormGroupWithPopover>
     );
   }
 
@@ -81,6 +98,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
     <FieldSizeHelperText
       remainingQuota={remainingQuota}
       isPreview={sizes[valueIndex]?.status === "preview"}
+      isUnavailable={sizes[valueIndex]?.isDisabled}
     />
   );
   const helperTextOverQuota = (
@@ -95,7 +113,9 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
   };
 
   const validation =
-    (validity !== "valid" || remainingQuota < value) && validity !== "trial"
+    (validity !== "valid" || remainingQuota < value) &&
+    validity !== "trial" &&
+    validity !== "required"
       ? "error"
       : "default";
 
@@ -110,7 +130,7 @@ export const FieldSize: VoidFunctionComponent<FieldSizeProps> = ({
       validated={validation}
       helperText={validity !== "trial" ? helperText : helperTextTrial}
       helperTextInvalid={
-        validity === "over-quota" ? helperTextOverQuota : undefined
+        validity === "over-quota" ? helperTextOverQuota : helperText
       }
     >
       <div className="pf-c-input-group pf-u-w-50">

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
@@ -25,3 +25,8 @@ export const TechPreview = Template.bind({});
 TechPreview.args = {
   isPreview: true,
 };
+
+export const Unavailable = Template.bind({});
+Unavailable.args = {
+  isUnavailable: true,
+};

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
@@ -37,3 +37,16 @@ UnavailableSubmitted.args = {
   isUnavailable: true,
   isError: true,
 };
+
+export const UnavailableAndTechPreview = Template.bind({});
+UnavailableAndTechPreview.args = {
+  isUnavailable: true,
+  isPreview: true,
+};
+
+export const UnavailableAndTechPreviewSubmitted = Template.bind({});
+UnavailableAndTechPreviewSubmitted.args = {
+  isUnavailable: true,
+  isPreview: true,
+  isError: true,
+};

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.stories.tsx
@@ -7,6 +7,7 @@ export default {
   args: {
     remainingQuota: 4,
     isPreview: false,
+    isError: false,
   },
   parameters: {
     backgrounds: {
@@ -29,4 +30,10 @@ TechPreview.args = {
 export const Unavailable = Template.bind({});
 Unavailable.args = {
   isUnavailable: true,
+};
+
+export const UnavailableSubmitted = Template.bind({});
+UnavailableSubmitted.args = {
+  isUnavailable: true,
+  isError: true,
 };

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
@@ -6,7 +6,8 @@ import { ExternalLink } from "../../../shared";
 export const FieldSizeHelperText: VoidFunctionComponent<{
   remainingQuota: number;
   isPreview: boolean;
-}> = ({ remainingQuota, isPreview }) => {
+  isUnavailable: boolean;
+}> = ({ remainingQuota, isPreview, isUnavailable }) => {
   const { t } = useTranslation("create-kafka-instance-with-sizes");
   return (
     <HelperText className={"pf-c-form__helper-text"}>
@@ -14,7 +15,19 @@ export const FieldSizeHelperText: VoidFunctionComponent<{
         count: remainingQuota,
       })}
 
-      {isPreview && (
+      {isUnavailable && (
+        <Alert
+          aria-live="polite"
+          role={"alert"}
+          className="pf-u-mb-md pf-u-mt-lg"
+          variant={AlertVariant.warning}
+          title={t("size_unavailable_title")}
+          isInline
+        >
+          {t("size_unavailable_message")}
+        </Alert>
+      )}
+      {isPreview && !isUnavailable && (
         <Alert
           aria-live="polite"
           role={"alert"}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
@@ -35,11 +35,11 @@ export const FieldSizeHelperText: VoidFunctionComponent<{
           {t("size_unavailable_message")}
         </Alert>
       )}
-      {isPreview && !isUnavailable && (
+      {isPreview && (
         <Alert
           aria-live="polite"
           role={"alert"}
-          className="pf-u-mb-md pf-u-mt-lg"
+          className={`pf-u-mb-md ${isUnavailable ? "" : "pf-u-mt-lg"}`}
           variant={AlertVariant.info}
           title={t("size_preview_title")}
           isInline

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
@@ -25,6 +25,7 @@ export const FieldSizeHelperText: VoidFunctionComponent<{
 
       {isUnavailable && (
         <Alert
+          id="instance-size-unavailable"
           aria-live="polite"
           role={"alert"}
           className="pf-u-mb-md pf-u-mt-lg"

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FieldSizeHelperText.tsx
@@ -1,4 +1,9 @@
-import { Alert, AlertVariant, HelperText } from "@patternfly/react-core";
+import {
+  Alert,
+  AlertVariant,
+  HelperText,
+  HelperTextItem,
+} from "@patternfly/react-core";
 import { VoidFunctionComponent } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { ExternalLink } from "../../../shared";
@@ -7,20 +12,23 @@ export const FieldSizeHelperText: VoidFunctionComponent<{
   remainingQuota: number;
   isPreview: boolean;
   isUnavailable: boolean;
-}> = ({ remainingQuota, isPreview, isUnavailable }) => {
+  isError: boolean;
+}> = ({ remainingQuota, isPreview, isUnavailable, isError }) => {
   const { t } = useTranslation("create-kafka-instance-with-sizes");
   return (
     <HelperText className={"pf-c-form__helper-text"}>
-      {t("standard_kafka_streaming_unit", {
-        count: remainingQuota,
-      })}
+      <HelperTextItem>
+        {t("standard_kafka_streaming_unit", {
+          count: remainingQuota,
+        })}
+      </HelperTextItem>
 
       {isUnavailable && (
         <Alert
           aria-live="polite"
           role={"alert"}
           className="pf-u-mb-md pf-u-mt-lg"
-          variant={AlertVariant.warning}
+          variant={isError ? "danger" : "warning"}
           title={t("size_unavailable_title")}
           isInline
         >

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/FormAlerts.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/FormAlerts.tsx
@@ -10,7 +10,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { CreateKafkaInstanceError } from "../types";
 
 export type FormAlertsProps = {
-  error: CreateKafkaInstanceError | undefined;
+  error: CreateKafkaInstanceError | "form-invalid" | undefined;
   onClickContactUS: () => void;
   streamingUnits?: number;
   maxStreamingUnits?: number;

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfoSkeleton.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/InstanceInfoSkeleton.tsx
@@ -5,20 +5,24 @@ import {
   CardBody,
   CardTitle,
   DescriptionList,
+  DescriptionListDescription,
   DescriptionListGroup,
+  DescriptionListTerm,
   Grid,
   GridItem,
   Skeleton,
   Stack,
   StackItem,
 } from "@patternfly/react-core";
+import ClockIcon from "@patternfly/react-icons/dist/js/icons/outlined-clock-icon";
 import { VoidFunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { InstanceInfoProps } from "./InstanceInfo";
 
-export const InstanceInfoSkeleton: VoidFunctionComponent<
-  Pick<InstanceInfoProps, "onClickQuickStart">
-> = ({ onClickQuickStart }) => {
+export const InstanceInfoSkeleton: VoidFunctionComponent<InstanceInfoProps> = ({
+  isTrial,
+  onClickQuickStart,
+}) => {
   const { t } = useTranslation("create-kafka-instance-with-sizes");
   return (
     <Stack hasGutter data-testid={"instance-info"}>
@@ -29,29 +33,88 @@ export const InstanceInfoSkeleton: VoidFunctionComponent<
             <DescriptionList isCompact>
               <DescriptionListGroup>
                 <Grid sm={6} lg={12} hasGutter>
+                  {!isTrial && (
+                    <GridItem>
+                      <DescriptionListTerm>
+                        {t("common:size")}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Skeleton
+                          width="35%"
+                          screenreaderText="Loading contents"
+                        />
+                      </DescriptionListDescription>
+                    </GridItem>
+                  )}
+                  {isTrial && (
+                    <GridItem>
+                      <DescriptionListTerm>
+                        {t("kafka:duration")}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <ClockIcon color="var(--pf-global--info-color--100)" />{" "}
+                        <Skeleton
+                          width="35%"
+                          screenreaderText="Loading contents"
+                        />
+                      </DescriptionListDescription>
+                    </GridItem>
+                  )}
                   <GridItem>
-                    <Skeleton width="75%" screenreaderText="Loading contents" />
+                    <DescriptionListTerm>
+                      {t("kafka:ingress")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="75%" />
+                    </DescriptionListDescription>
                   </GridItem>
                   <GridItem>
-                    <Skeleton width="66%" />
+                    <DescriptionListTerm>
+                      {t("kafka:egress")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="66%" />
+                    </DescriptionListDescription>
                   </GridItem>
                   <GridItem>
-                    <Skeleton width="66%" />
+                    <DescriptionListTerm>
+                      {t("kafka:storage")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="66%" />
+                    </DescriptionListDescription>
                   </GridItem>
                   <GridItem>
-                    <Skeleton width="50%" />
+                    <DescriptionListTerm>
+                      {t("kafka:partitions")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="50%" />
+                    </DescriptionListDescription>
                   </GridItem>
                   <GridItem>
-                    <Skeleton width="33%" />
+                    <DescriptionListTerm>
+                      {t("kafka:client_connections")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="33%" />
+                    </DescriptionListDescription>
                   </GridItem>
                   <GridItem>
-                    <Skeleton width="25%" />
+                    <DescriptionListTerm>
+                      {t("kafka:connection_rate")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="25%" />
+                    </DescriptionListDescription>
                   </GridItem>
                   <GridItem>
-                    <Skeleton width="55%" />
-                  </GridItem>
-                  <GridItem>
-                    <Skeleton width="35%" />
+                    <DescriptionListTerm>
+                      {t("kafka:message_size")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Skeleton width="55%" />
+                    </DescriptionListDescription>
                   </GridItem>
                 </Grid>
               </DescriptionListGroup>

--- a/src/Kafka/CreateKafkaInstanceWithSizes/components/ModalAlerts.tsx
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/components/ModalAlerts.tsx
@@ -113,6 +113,10 @@ export const ModalAlerts: VoidFunctionComponent<ModalAlertsProps> = ({
               </Alert>
             );
           case instanceAvailability === "trial-unavailable":
+          case plan === "trial" &&
+            instanceAvailability === "regions-unavailable":
+          case plan === "trial" &&
+            instanceAvailability === "instance-unavailable":
             return (
               <Alert
                 role={"alert"}

--- a/src/Kafka/CreateKafkaInstanceWithSizes/types.ts
+++ b/src/Kafka/CreateKafkaInstanceWithSizes/types.ts
@@ -13,7 +13,7 @@ export type Region = string;
 export type RegionInfo = {
   id: Region;
   displayName: string;
-  isDisabled?: boolean;
+  isDisabled: boolean;
 };
 export type AZ = "single" | "multi";
 export type ProviderInfo = {
@@ -37,13 +37,13 @@ export type Size = {
   maxPartitions: number;
   messageSize: number;
   trialDurationHours: number | undefined;
+  isDisabled: boolean;
 };
 
 export type CreateKafkaInstanceError =
   | "over-quota"
   | "name-taken"
   | "trial-unavailable"
-  | "form-invalid"
   | "region-unavailable"
   | "unknown";
 

--- a/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.test.tsx
@@ -13,7 +13,7 @@ describe("Metric lag", () => {
     expect(await comp.findByText("Metrics experience lag")).toBeInTheDocument();
     expect(
       await comp.findByText(
-        "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages."
+        "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync with details displayed on other pages."
       )
     ).toBeInTheDocument();
 
@@ -24,7 +24,7 @@ describe("Metric lag", () => {
     ).not.toBeInTheDocument();
     expect(
       await comp.queryByText(
-        "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync and with details displayed on other pages."
+        "Metrics regularly experience lag, and do not automatically refresh. This might result in metrics appearing out-of-sync with details displayed on other pages."
       )
     ).not.toBeInTheDocument();
   });


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a number of issues with the create Kafka dialog.

### Sizes can be disabled

An instance size could be visible but not selectable for instance creation. It shows with a warning.
![image](https://user-images.githubusercontent.com/966316/170322447-4ea168a6-85ed-4cda-9f91-d571d820af9a.png)

Trying to submit the form with a disabled size selected will transform the warning in an error.
![image](https://user-images.githubusercontent.com/966316/170322614-66259d46-4e77-4b39-b71f-86590b0d4718.png)

### Generic alert when trial instances are unavailable for technical reasons

Always display the "All available trial instances are currently in use. Try again later." message for all cases where trial instances can not be created for reasons unrelated to the user.

### Top aligned modal

Aligning the modal to the top of the screen reduces the amount of layout jumping when interacting with elements that trigger changes on the visualized UI, like changing provider/region where skeletons are displayed while loading the new data.

Skeletons were tweaked to better reflect the space taken by the real elements, again to reduce layout jumping.

### State machine refactoring

Refactor the state machine to rely less on the context and more on its states. This will improve the future maintainability of the machine.

### Fix the XState inspector height issue

The inspector will use the available height instead of a fixed 1000px.

### Improve rollup.js build

Suppress the warnings, by properly acknowledging them. Change the config so that future warnings are promoted to errors, forcing builds to fail.