### PR TITLE
chore: Add data-ouia-component-id for create topic button

### DIFF
--- a/src/Kafka/Metrics/components/EmptyStateNoTopics.test.tsx
+++ b/src/Kafka/Metrics/components/EmptyStateNoTopics.test.tsx
@@ -1,0 +1,16 @@
+import { composeStories } from "@storybook/testing-react";
+import { render, waitForI18n } from "../../../test-utils"
+import * as stories from "./EmptyStateNoTopics.stories";
+
+const { WithCTA } = composeStories(stories);
+
+describe("Create button", () => {
+  it("should persist ouia id for create button", async () => {
+    const comp = render(<WithCTA />);
+    await waitForI18n(comp);
+    expect(comp.getByRole("button", { name: "Create topic" })).toHaveAttribute(
+      "data-ouia-component-id",
+      "button-create"
+    );
+  });
+});

--- a/src/Kafka/Metrics/components/EmptyStateNoTopics.test.tsx
+++ b/src/Kafka/Metrics/components/EmptyStateNoTopics.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/testing-react";
-import { render, waitForI18n } from "../../../test-utils"
+import { render, waitForI18n } from "../../../test-utils";
 import * as stories from "./EmptyStateNoTopics.stories";
 
 const { WithCTA } = composeStories(stories);

--- a/src/Kafka/Metrics/components/EmptyStateNoTopics.tsx
+++ b/src/Kafka/Metrics/components/EmptyStateNoTopics.tsx
@@ -25,7 +25,7 @@ export const EmptyStateNoTopics: FunctionComponent<EmptyStateNoTopicsProps> = ({
       </Title>
       <EmptyStateBody>{t("metrics:empty_state_no_topics_body")}</EmptyStateBody>
       {onCreateTopic && (
-        <Button variant="primary" onClick={onCreateTopic}>
+        <Button ouiaId="button-create" variant="primary" onClick={onCreateTopic}>
           {t("metrics:empty_state_no_topics_create_topic")}
         </Button>
       )}

--- a/src/Kafka/Metrics/components/EmptyStateNoTopics.tsx
+++ b/src/Kafka/Metrics/components/EmptyStateNoTopics.tsx
@@ -25,7 +25,11 @@ export const EmptyStateNoTopics: FunctionComponent<EmptyStateNoTopicsProps> = ({
       </Title>
       <EmptyStateBody>{t("metrics:empty_state_no_topics_body")}</EmptyStateBody>
       {onCreateTopic && (
-        <Button ouiaId="button-create" variant="primary" onClick={onCreateTopic}>
+        <Button
+          ouiaId="button-create"
+          variant="primary"
+          onClick={onCreateTopic}
+        >
           {t("metrics:empty_state_no_topics_create_topic")}
         </Button>
       )}


### PR DESCRIPTION
**What this PR does / why we need it**:

> Add data-ouia-component-id for create topic button

**Which issue(s) this PR fixes** 

> https://issues.redhat.com/browse/MGDSTRM-8695

