### PR TITLE
chore: Select user manually even if it does not exist on the list of options

### DIFF
--- a/src/Kafka/ManageKafkaPermissions/ManageKafkaPermisions.test.tsx
+++ b/src/Kafka/ManageKafkaPermissions/ManageKafkaPermisions.test.tsx
@@ -31,5 +31,17 @@ describe("ManagePermissionsModal", () => {
 
     expect(button).toBeDisabled();
     expect(await comp.findByText("Required")).toBeInTheDocument();
+    userEvent.type(await comp.findByLabelText("Account"), "manual-select");
+    const option = await comp.findByText('Use "manual-select"');
+    expect(option).toBeInTheDocument();
+    userEvent.click(option);
+    expect(comp.queryByText("Required")).not.toBeInTheDocument();
+    userEvent.click(await comp.findByLabelText("Close"));
+    expect(hideModal).toBeCalledTimes(1);
+    userEvent.click(await comp.findByText("Cancel"));
+    expect(hideModal).toBeCalledTimes(2);
+    expect(button).toBeEnabled();
+    userEvent.type(comp.getByRole("dialog"), "{esc}");
+    expect(hideModal).toBeCalledTimes(3);
   });
 });

--- a/src/Kafka/ManageKafkaPermissions/ManageKafkaPermissions.tsx
+++ b/src/Kafka/ManageKafkaPermissions/ManageKafkaPermissions.tsx
@@ -29,10 +29,6 @@ export const ManageKafkaPermissions: React.FC<ManageKafkaPermissionsProps> = ({
     }
   };
 
-  const setEscapeClosesModal = (closes: boolean) => {
-    escapeClosesModal.current = closes;
-  };
-
   return (
     <Modal
       id="manage-permissions-modal"
@@ -71,7 +67,6 @@ export const ManageKafkaPermissions: React.FC<ManageKafkaPermissionsProps> = ({
           value={selectedAccount}
           onChangeAccount={setSelectedAccount}
           accounts={accounts}
-          onEscapeModal={setEscapeClosesModal}
         />
       </Form>
     </Modal>

--- a/src/Kafka/ManageKafkaPermissions/components/SelectAccount.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/SelectAccount.stories.tsx
@@ -157,3 +157,14 @@ CanExpandOverDialog.parameters = {
     },
   },
 };
+
+export const ValidSelection = Template.bind({});
+ValidSelection.args = { value: "id2" };
+
+ValidSelection.parameters = {
+  docs: {
+    description: {
+      story: `Valid value is selected`,
+    },
+  },
+};

--- a/src/Kafka/ManageKafkaPermissions/components/SelectAccount.test.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/SelectAccount.test.tsx
@@ -9,18 +9,14 @@ const {
   OnlyServiceAccounts,
   OnlyUserAccounts,
   InteractiveExample,
+  ValidSelection,
 } = composeStories(stories);
 
 describe("Select Account", () => {
   it("should render a select component", async () => {
     const onChangeAccount = jest.fn();
-    const onEscapeModal = jest.fn();
-    const comp = render(
-      <EmptyState
-        onChangeAccount={onChangeAccount}
-        onEscapeModal={onEscapeModal}
-      />
-    );
+
+    const comp = render(<EmptyState onChangeAccount={onChangeAccount} />);
 
     await waitForI18n(comp);
     userEvent.click(await comp.findByLabelText("Account"));
@@ -30,16 +26,25 @@ describe("Select Account", () => {
     expect(comp.getByText("Service accounts")).toBeInTheDocument();
     expect(comp.getByText("User accounts")).toBeInTheDocument();
     expect(comp.getByText("id2")).toBeInTheDocument();
+    userEvent.click(await comp.findByText("id2"));
+    expect(onChangeAccount).toBeCalled();
+    userEvent.type(
+      comp.getByPlaceholderText("Select an account"),
+      "manual-entry"
+    );
+    await waitForPopper();
+    const option = await comp.findByText('Use "manual-entry"');
+    expect(option).toBeInTheDocument();
+    userEvent.click(option);
+    expect(comp.queryByText("Required")).not.toBeInTheDocument();
+    expect(onChangeAccount).toBeCalled();
   });
 
   it("should show empty list of options", async () => {
     const onChangeAccount = jest.fn();
-    const onEscapeModal = jest.fn();
+
     const comp = render(
-      <NoServiceOrUserAccounts
-        onChangeAccount={onChangeAccount}
-        onEscapeModal={onEscapeModal}
-      />
+      <NoServiceOrUserAccounts onChangeAccount={onChangeAccount} />
     );
     await waitForI18n(comp);
 
@@ -54,12 +59,9 @@ describe("Select Account", () => {
 
   it("should show list of service accounts while showing empty user accounts", async () => {
     const onChangeAccount = jest.fn();
-    const onEscapeModal = jest.fn();
+
     const comp = render(
-      <OnlyServiceAccounts
-        onChangeAccount={onChangeAccount}
-        onEscapeModal={onEscapeModal}
-      />
+      <OnlyServiceAccounts onChangeAccount={onChangeAccount} />
     );
     await waitForI18n(comp);
 
@@ -75,13 +77,8 @@ describe("Select Account", () => {
 
   it("should show list of user accounts while showing empty service accounts", async () => {
     const onChangeAccount = jest.fn();
-    const onEscapeModal = jest.fn();
-    const comp = render(
-      <OnlyUserAccounts
-        onChangeAccount={onChangeAccount}
-        onEscapeModal={onEscapeModal}
-      />
-    );
+
+    const comp = render(<OnlyUserAccounts onChangeAccount={onChangeAccount} />);
     await waitForI18n(comp);
 
     userEvent.click(await comp.findByLabelText("Account"));
@@ -96,13 +93,9 @@ describe("Select Account", () => {
 
   it("should show a select component ", async () => {
     const onChangeAccount = jest.fn();
-    const onEscapeModal = jest.fn();
 
     const comp = render(
-      <InteractiveExample
-        onChangeAccount={onChangeAccount}
-        onEscapeModal={onEscapeModal}
-      />
+      <InteractiveExample onChangeAccount={onChangeAccount} />
     );
     await waitForI18n(comp);
 
@@ -117,5 +110,30 @@ describe("Select Account", () => {
       "ServiceAccount2"
     );
     userEvent.click(comp.getByText("ServiceAccount2"));
+    await waitForPopper();
+    userEvent.click(await comp.findByLabelText("Clear all"));
+    expect(comp.getByText("Required")).toBeInTheDocument();
+    userEvent.click(await comp.findByLabelText("Account"));
+    await waitForPopper();
+    userEvent.type(
+      comp.getByPlaceholderText("Select an account"),
+      "manual-entry"
+    );
+    await waitForPopper();
+    const option = await comp.findByText('Use "manual-entry"');
+    expect(option).toBeInTheDocument();
+    userEvent.click(option);
+    expect(comp.queryByText("Required")).not.toBeInTheDocument();
+  });
+
+  it("should show a select component with valid value selected ", async () => {
+    const onChangeAccount = jest.fn();
+
+    const comp = render(<ValidSelection onChangeAccount={onChangeAccount} />);
+    await waitForI18n(comp);
+    expect(comp.getByDisplayValue("id2")).toBeInTheDocument();
+    userEvent.click(await comp.findByLabelText("Clear all"));
+    expect(comp.getByText("Required")).toBeInTheDocument();
+    expect(onChangeAccount).toBeCalledTimes(1);
   });
 });

--- a/src/Kafka/ManageKafkaPermissions/components/SelectAccount.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/SelectAccount.tsx
@@ -164,11 +164,17 @@ export const SelectAccount: React.VFC<SelectAccountProps> = ({
         onFilter={(_, value) => makeOptions(value)}
         isOpen={isOpen}
         placeholderText={t("account_id_typeahead_placeholder")}
-        isCreatable={false}
+        isCreatable={true}
         menuAppendTo="parent"
         validated={validated}
+        createText={t("resourcePrefix.create_text")}
         isGrouped={true}
         maxHeight={400}
+        onCreateOption={(value: string) => {
+          onChangeAccount(value);
+          setIsOpen(false);
+          setIsDirty(true);
+        }}
       >
         {makeOptions()}
       </Select>

--- a/src/Kafka/ManageKafkaPermissions/components/SelectAccount.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/SelectAccount.tsx
@@ -18,7 +18,6 @@ export type SelectAccountProps = {
   accounts: Account[];
   initialOpen?: boolean;
   onChangeAccount: (value: string | undefined) => void;
-  onEscapeModal: (closes: boolean) => void;
 };
 
 export const SelectAccount: React.VFC<SelectAccountProps> = ({
@@ -26,7 +25,6 @@ export const SelectAccount: React.VFC<SelectAccountProps> = ({
   accounts,
   initialOpen = false,
   onChangeAccount,
-  onEscapeModal,
 }) => {
   const { t } = useTranslation(["manage-kafka-permissions"]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -36,15 +34,12 @@ export const SelectAccount: React.VFC<SelectAccountProps> = ({
   useLayoutEffect(() => setIsOpen(initialOpen), [initialOpen]);
 
   const onToggle = (newState: boolean) => {
-    if (newState) {
-      onEscapeModal(false);
-    } else onEscapeModal(true);
-
     setIsOpen(newState);
   };
 
   const clearSelection = () => {
     onChangeAccount(undefined);
+    setIsDirty(true);
     setIsOpen(false);
   };
 
@@ -133,14 +128,13 @@ export const SelectAccount: React.VFC<SelectAccountProps> = ({
 
   const onSelect: SelectProps["onSelect"] = (_, value) => {
     onChangeAccount(value as string);
-    setIsDirty(true);
+    setIsDirty(false);
     setIsOpen(false);
   };
 
-  const validated: ValidatedOptions =
-    isDirty && value === undefined
-      ? ValidatedOptions.error
-      : ValidatedOptions.default;
+  const validated: ValidatedOptions = isDirty
+    ? ValidatedOptions.error
+    : ValidatedOptions.default;
 
   return (
     <FormGroupWithPopover
@@ -170,10 +164,9 @@ export const SelectAccount: React.VFC<SelectAccountProps> = ({
         createText={t("resourcePrefix.create_text")}
         isGrouped={true}
         maxHeight={400}
-        onCreateOption={(value: string) => {
-          onChangeAccount(value);
+        onCreateOption={() => {
           setIsOpen(false);
-          setIsDirty(true);
+          setIsDirty(false);
         }}
       >
         {makeOptions()}


### PR DESCRIPTION

**What this PR does / why we need it**:

> This PR adds an option to include manual entry when selecting an account. 

**Which issue(s) this PR fixes** 

This PR closes [8377](https://issues.redhat.com/browse/MGDSTRM-8377)

**Verification steps** 

To view the story, navigate to ManageKafkaPermissions/Empty State

