### PR TITLE
chore: add navigation modal for topic properties page - storybook PoC

### DIFF
--- a/src/ProofOfConcepts/Navigation Modal/navigationModal.stories.tsx
+++ b/src/ProofOfConcepts/Navigation Modal/navigationModal.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import React from "react";
+
+import { NavigationModal } from "./navigationModal";
+
+export default {
+  title: "ProofOfConcepts/NavigationModal",
+  component: NavigationModal,
+  args: {},
+} as ComponentMeta<typeof NavigationModal>;
+
+const Template: ComponentStory<typeof NavigationModal> = (args) => (
+  <NavigationModal {...args} />
+);
+
+export const Story = Template.bind({});
+Story.args = {};

--- a/src/ProofOfConcepts/Navigation Modal/navigationModal.tsx
+++ b/src/ProofOfConcepts/Navigation Modal/navigationModal.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Modal, ModalVariant, Button } from "@patternfly/react-core";
+
+export class NavigationModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false,
+    };
+    this.handleModalToggle = () => {
+      this.setState(({ isModalOpen }) => ({
+        isModalOpen: !isModalOpen,
+      }));
+    };
+  }
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show small modal
+        </Button>
+        <Modal
+          variant={ModalVariant.small}
+          title="Leave page without saving?"
+          isOpen={isModalOpen}
+          onClose={this.handleModalToggle}
+          actions={[
+            <Button
+              key="confirm"
+              variant="primary"
+              onClick={this.handleModalToggle}
+            >
+              Leave
+            </Button>,
+            <Button
+              key="cancel"
+              variant="link"
+              onClick={this.handleModalToggle}
+            >
+              Stay
+            </Button>,
+          ]}
+        >
+          Changes you made to the topic properties will be lost.
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}


### PR DESCRIPTION
PoC for https://issues.redhat.com/browse/MGDSTRM-3797

A prompt that will appear, when navigating away from the create topic screen or edit topic screen warning the user that data entered in the form will be lost if they navigate away

<img width="834" alt="Screenshot 2022-06-14 at 09 41 01" src="https://user-images.githubusercontent.com/89915947/173533937-6e23163b-fcb6-4c9a-85f1-8ca82c6af3de.png">


> guidance on how to go the particular story.

Proof Of Concepts -> Navigation Modal

Is yet to be implemented from PoC to production-ready code

