### PR TITLE
chore: POC add modal to warn user when they are leaving to accept T&C

### DIFF
--- a/locales/en/manage-kafka-permissions.json
+++ b/locales/en/manage-kafka-permissions.json
@@ -11,7 +11,6 @@
   "dialog_aria_label": "Manage access dialog",
   "dialog_title": "Manage access",
   "is_kafka_instance": "is '{{value}}' ",
-  "is_kafka_instane": "",
   "kafka_instance": "$t(common:kafka) instance",
   "no_results_found": "No results found",
   "operations": {

--- a/src/ProofOfConcepts/TAndCModal/tAndCModal.stories.tsx
+++ b/src/ProofOfConcepts/TAndCModal/tAndCModal.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import React from "react";
+
+import { SmallModal } from "./tAndCModal";
+
+export default {
+  title: "PoC/SmallModal",
+  component: SmallModal,
+  args: {},
+} as ComponentMeta<typeof SmallModal>;
+
+const Template: ComponentStory<typeof SmallModal> = (args) => (
+  <SmallModal {...args} />
+);
+
+export const Story = Template.bind({});
+Story.args = {};

--- a/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
+++ b/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
@@ -1,0 +1,61 @@
+import React, { VoidFunctionComponent } from "react";
+import { Modal, ModalVariant, Button } from "@patternfly/react-core";
+
+var linebreak = "\n";
+
+export class SmallModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false,
+    };
+    this.handleModalToggle = () => {
+      this.setState(({ isModalOpen }) => ({
+        isModalOpen: !isModalOpen,
+      }));
+    };
+  }
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show small modal
+        </Button>
+        <Modal
+          id="modalTerms"
+          variant={ModalVariant.small}
+          title="Terms and Conditions"
+          isOpen={isModalOpen}
+          onClose={this.handleModalToggle}
+          actions={[
+            <Button
+              key="confirm"
+              variant="primary"
+              data-testid="actionViewTerms"
+              onClick={this.handleModalToggle}
+            >
+              View Terms and Conditions
+            </Button>,
+            <Button
+              key="cancel"
+              variant="link"
+              data-testid="actionCancelViewTerms"
+              onClick={this.handleModalToggle}
+            >
+              Cancel
+            </Button>,
+          ]}
+        >
+          <div>Red Hat has Terms and Conditions for its managed services.</div>
+          <div class="pf-u-font-weight-bold">
+            If you do not accept the terms, you will not be able to create new
+            Kafka instances.
+          </div>
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}

--- a/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
+++ b/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
@@ -50,15 +50,15 @@ export class SmallModal extends React.Component {
         >
           <Flex direction={{ default: "column" }}>
             <FlexItem>
-              <div>
-                Red Hat has Terms and Conditions for its managed services.
-              </div>
+              <p>Red Hat has Terms and Conditions for its managed services.</p>
             </FlexItem>
             <FlexItem>
-              <div class="pf-u-font-weight-bold">
-                If you do not accept the terms, you will not be able to create
-                new Kafka instances.
-              </div>
+              <p>
+                <strong>
+                  If you do not accept the terms, you will not be able to create
+                  new Kafka instances.
+                </strong>
+              </p>
             </FlexItem>
           </Flex>
         </Modal>

--- a/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
+++ b/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
@@ -1,7 +1,18 @@
 import React, { VoidFunctionComponent } from "react";
 import { Modal, ModalVariant, Button } from "@patternfly/react-core";
-
+import { Flex, FlexItem } from "@patternfly/react-core";
 var linebreak = "\n";
+
+//import React from 'react';
+//import { Flex, FlexItem } from '@patternfly/react-core';
+
+//const ColumnLayout = () => (
+//<Flex direction={{ default: 'column' }}>
+//<FlexItem>Flex item</FlexItem>
+//<FlexItem>Flex item</FlexItem>
+//<FlexItem>Flex item</FlexItem>
+//</Flex>
+//)
 
 export class SmallModal extends React.Component {
   constructor(props) {
@@ -49,11 +60,19 @@ export class SmallModal extends React.Component {
             </Button>,
           ]}
         >
-          <div>Red Hat has Terms and Conditions for its managed services.</div>
-          <div class="pf-u-font-weight-bold">
-            If you do not accept the terms, you will not be able to create new
-            Kafka instances.
-          </div>
+          <Flex direction={{ default: "column" }}>
+            <FlexItem>
+              <div>
+                Red Hat has Terms and Conditions for its managed services.
+              </div>
+            </FlexItem>
+            <FlexItem>
+              <div class="pf-u-font-weight-bold">
+                If you do not accept the terms, you will not be able to create
+                new Kafka instances.
+              </div>
+            </FlexItem>
+          </Flex>
         </Modal>
       </React.Fragment>
     );

--- a/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
+++ b/src/ProofOfConcepts/TAndCModal/tAndCModal.tsx
@@ -1,18 +1,6 @@
 import React, { VoidFunctionComponent } from "react";
 import { Modal, ModalVariant, Button } from "@patternfly/react-core";
 import { Flex, FlexItem } from "@patternfly/react-core";
-var linebreak = "\n";
-
-//import React from 'react';
-//import { Flex, FlexItem } from '@patternfly/react-core';
-
-//const ColumnLayout = () => (
-//<Flex direction={{ default: 'column' }}>
-//<FlexItem>Flex item</FlexItem>
-//<FlexItem>Flex item</FlexItem>
-//<FlexItem>Flex item</FlexItem>
-//</Flex>
-//)
 
 export class SmallModal extends React.Component {
   constructor(props) {


### PR DESCRIPTION
**What this PR does / why we need it**:

> Warn user that they are leaving to accept T&C. When making a Kafka Instance for the first time, they are directed to new screen where they accept the T&C flow, this caused confusion where some ignored the screen and tried to continue without accepting. 

**Verification steps** 
![TandCModal](https://user-images.githubusercontent.com/72694484/173565496-b28f779c-62c8-4139-9a8c-444b9cfa6bae.png)


>Story can be found in < POC > < SmallModal > < Story >

**Special notes for your reviewer**:
>There might need to be extra space between normal and bold text
