### PR TITLE
chore: Fix the padding issue for Metrics lag alert in metrics dashboard

### DIFF
--- a/src/Kafka/Metrics/Metrics.tsx
+++ b/src/Kafka/Metrics/Metrics.tsx
@@ -18,7 +18,6 @@ import { useKafkaInstanceMetrics } from "./useKafkaInstanceMetrics";
 import { useMetricsKpi } from "./useMetricsKpi";
 import { useTopicsMetrics } from "./useTopicsMetrics";
 import { PartitionCard } from "./components/PartitionCard";
-import { Stack, StackItem } from "@patternfly/react-core";
 import { MetricsLagAlert } from "./components/MetricsLagAlert";
 
 export type MetricsProps = {
@@ -83,48 +82,38 @@ const ConnectedMetrics: VoidFunctionComponent<ConnectedMetricsProps> = ({
       return <EmptyStateMetricsUnavailable />;
     default:
       return (
-        <Stack hasGutter>
-          <StackItem>
+        <MetricsLayout
+          metricsLagAlert={
             <MetricsLagAlert onClickClose={onClickClose} isClosed={isClosed} />
-          </StackItem>
-          <StackItem>
-            <MetricsLayout
-              topicsKpi={
-                <CardKpi
-                  metric={metricsKpi.topics}
-                  isLoading={
-                    metricsKpi.isInitialLoading || metricsKpi.isLoading
-                  }
-                  name={t("metrics:metric_kpi_topics_name")}
-                  popover={t("metrics:metric_kpi_topics_description")}
-                />
-              }
-              topicPartitionsKpi={
-                <PartitionCard
-                  metric={metricsKpi.topicPartitions}
-                  isLoading={
-                    metricsKpi.isInitialLoading || metricsKpi.isLoading
-                  }
-                  topicPartitionsLimit={metricsKpi.topicPartitionsLimit}
-                />
-              }
-              consumerGroupKpi={
-                <CardKpi
-                  metric={metricsKpi.consumerGroups}
-                  isLoading={
-                    metricsKpi.isInitialLoading || metricsKpi.isLoading
-                  }
-                  name={t("metrics:metric_kpi_consumerGroup_name")}
-                  popover={t("metrics:metric_kpi_consumerGroup_description")}
-                />
-              }
-              diskSpaceMetrics={<ConnectedKafkaInstanceMetrics />}
-              topicMetrics={
-                <ConnectedTopicsMetrics onCreateTopic={onCreateTopic} />
-              }
+          }
+          topicsKpi={
+            <CardKpi
+              metric={metricsKpi.topics}
+              isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
+              name={t("metrics:metric_kpi_topics_name")}
+              popover={t("metrics:metric_kpi_topics_description")}
             />
-          </StackItem>
-        </Stack>
+          }
+          topicPartitionsKpi={
+            <PartitionCard
+              metric={metricsKpi.topicPartitions}
+              isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
+              topicPartitionsLimit={metricsKpi.topicPartitionsLimit}
+            />
+          }
+          consumerGroupKpi={
+            <CardKpi
+              metric={metricsKpi.consumerGroups}
+              isLoading={metricsKpi.isInitialLoading || metricsKpi.isLoading}
+              name={t("metrics:metric_kpi_consumerGroup_name")}
+              popover={t("metrics:metric_kpi_consumerGroup_description")}
+            />
+          }
+          diskSpaceMetrics={<ConnectedKafkaInstanceMetrics />}
+          topicMetrics={
+            <ConnectedTopicsMetrics onCreateTopic={onCreateTopic} />
+          }
+        />
       );
   }
 };

--- a/src/Kafka/Metrics/components/MetricsLagAlert.tsx
+++ b/src/Kafka/Metrics/components/MetricsLagAlert.tsx
@@ -1,5 +1,5 @@
 import type { VoidFunctionComponent } from "react";
-import { Alert, AlertActionCloseButton, Card } from "@patternfly/react-core";
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 
 export type MetricsLagAlertProps = {
@@ -15,16 +15,14 @@ export const MetricsLagAlert: VoidFunctionComponent<MetricsLagAlertProps> = ({
 
   if (!isClosed) {
     return (
-      <Card>
-        <Alert
-          isInline
-          variant="info"
-          title={t("metrics_lag_title")}
-          actionClose={<AlertActionCloseButton onClose={onClickClose} />}
-        >
-          <p>{t("metrics_lag_description")}</p>
-        </Alert>
-      </Card>
+      <Alert
+        isInline
+        variant="info"
+        title={t("metrics_lag_title")}
+        actionClose={<AlertActionCloseButton onClose={onClickClose} />}
+      >
+        <p>{t("metrics_lag_description")}</p>
+      </Alert>
     );
   } else {
     return <> </>;

--- a/src/Kafka/Metrics/components/MetricsLayout.tsx
+++ b/src/Kafka/Metrics/components/MetricsLayout.tsx
@@ -2,6 +2,7 @@ import { Grid, GridItem, PageSection } from "@patternfly/react-core";
 import type { ReactElement, FunctionComponent } from "react";
 
 type MetricsLayoutProps = {
+  metricsLagAlert: ReactElement;
   topicsKpi: ReactElement;
   topicPartitionsKpi: ReactElement;
   consumerGroupKpi: ReactElement;
@@ -9,6 +10,7 @@ type MetricsLayoutProps = {
   topicMetrics: ReactElement;
 };
 export const MetricsLayout: FunctionComponent<MetricsLayoutProps> = ({
+  metricsLagAlert,
   topicsKpi,
   topicPartitionsKpi,
   consumerGroupKpi,
@@ -18,6 +20,7 @@ export const MetricsLayout: FunctionComponent<MetricsLayoutProps> = ({
   return (
     <PageSection>
       <Grid hasGutter>
+        <GridItem>{metricsLagAlert}</GridItem>
         <GridItem sm={4}>{topicsKpi}</GridItem>
         <GridItem sm={4}>{topicPartitionsKpi}</GridItem>
         <GridItem sm={4}>{consumerGroupKpi}</GridItem>


### PR DESCRIPTION
**What this PR does / why we need it**:

> Fix the padding issue for the Metrics lag alert in the metrics dashboard

**Which issue(s) this PR fixes** 

> https://issues.redhat.com/browse/MGDSTRM-8180 (see the comment section for description of the issue)

**Verification steps** 
https://619e1921b3e38b003afeb2be-wnmpynbryf.chromatic.com/?path=/story/kafka-metrics--all-ready&globals=withInsightsChrome:true