### PR TITLE
fix: change epoch from string to int value

### DIFF
--- a/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
@@ -147,7 +147,7 @@ export const FilterGroup: VoidFunctionComponent<FilterGroupProps> = ({
               }
             }}
             value={
-              timestamp ? formatInTimeZone(parseISO(timestamp), "UTC", "t") : ""
+              timestamp ? Math.floor(parseISO(timestamp).getTime() / 1000) : ""
             }
           />
         )}


### PR DESCRIPTION
**What this PR does / why we need it**:

When selecting my filter options I set it to Epoch timestamp. If I enter any valid number the UI displays a negative number even when using the UI buttons for iteration of the number. When typing a large number into the field (about 9 digits) the whole UI crashes and I get an error page. Note even the large number is displayed as negative when crashing.



**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/MGDSTRM-8958

**Verification steps** 

<img width="542" alt="Screenshot 2022-06-24 at 17 43 11" src="https://user-images.githubusercontent.com/981838/175603074-f33478c0-4b07-4202-9e2b-b3563598a196.png">

 
**Is there any work left / what's next** :

I wasn't sure if we actually want to start with empty string. 
I would probably put current time `new Date().getTime` as initial value instead of 
empty string. This is more UX issue so left it as it was before.


**Special notes for your reviewer**:


