### PR TITLE
chore: Remove service account translation

### DIFF
--- a/.storybook/withMas.tsx
+++ b/.storybook/withMas.tsx
@@ -36,8 +36,6 @@ export const withMas = (
                 import("../locales/en/kafkaoverview-v2.json"),
               "manage-kafka-permissions": () =>
                 import("../locales/en/manage-kafka-permissions.json"),
-              "service-account": () =>
-                import("../locales/en/service-account.json"),
               "message-browser": () =>
                 import("../locales/en/message-browser.json"),
               "overview-v2": () => import("../locales/en/overview-v2.json"),

--- a/locales/en/connection-tab.json
+++ b/locales/en/connection-tab.json
@@ -2,6 +2,7 @@
   "authentication_method": "Authentication method",
   "bootstrap_server": "Bootstrap server",
   "bootstrap_server_description": "Establish the initial connection between your client and Kafka instance.",
+  "create_service_account": "Create service account",
   "create_service_account_to_generate_credentials": "Create a service account to generate credentials. Manage the service accounts you create on the <value>Service Accounts</value> page.",
   "current_instance": "Accounts do not have access to this instance unless granted under the instance’s <value>Access tab</value>. The owner, the organization administrator, or users with the Allow Alter permission on this instance can manage access.",
   "drawer_resource_tab_body_description_1": "Your application or tool initially connects to the Kafka instance using the bootstrap server and authenticates with your service account credentials. You can also access the Kafka instance by calling the REST API using a token obtained from Red Hat SSO.",
@@ -25,5 +26,6 @@
   "sasl_oauthbearer_popover_content": "OpenShift Streams for Apache Kafka uses the industry-standard OAuth protocol via the SASL/OAUTHBEARER provided by Apache Kafka.",
   "sasl_plain": "SASL/PLAIN",
   "sasl_plain_description": "Use your service account credentials (Client ID and Client secret) as the user name and password to authenticate your client with the Kafka instance.",
+  "service_accounts_small": "Service accounts",
   "token_endpoint_url": "Token endpoint URL"
 }

--- a/locales/en/kafka.json
+++ b/locales/en/kafka.json
@@ -8,6 +8,7 @@
     "authentication_method": "Authentication method",
     "bootstrap_server": "Bootstrap server",
     "bootstrap_server_description": "Establish the initial connection between your client and Kafka instance.",
+    "create_service_account": "Create service account",
     "create_service_account_to_generate_credentials": "Create a service account to generate credentials. Manage the service accounts you create on the <value>Service Accounts</value> page.",
     "current_instance": "Accounts do not have access to this instance unless granted under the instance’s <value>Access tab</value>. The owner, the organization administrator, or users with the Allow Alter permission on this instance can manage access.",
     "drawer_resource_tab_body_description_1": "Your application or tool initially connects to the Kafka instance using the bootstrap server and authenticates with your service account credentials. You can also access the Kafka instance by calling the REST API using a token obtained from Red Hat SSO.",
@@ -30,6 +31,7 @@
     "sasl_oauthbearer_popover_content": "OpenShift Streams for Apache Kafka uses the industry-standard OAuth protocol via the SASL/OAUTHBEARER provided by Apache Kafka.",
     "sasl_plain": "SASL/PLAIN",
     "sasl_plain_description": "Use your service account credentials (Client ID and Client secret) as the user name and password to authenticate your client with the Kafka instance.",
+    "service_accounts_small": "Service accounts",
     "token_endpoint_url": "Token endpoint URL"
   },
   "consumerGroup": {

--- a/locales/en/service-account.json
+++ b/locales/en/service-account.json
@@ -1,4 +1,4 @@
 {
-  "create_service_account": "Create service account",
-  "service_accounts_small": "Service accounts"
+  "create_service_account": "",
+  "service_accounts_small": ""
 }

--- a/locales/en/service-account.json
+++ b/locales/en/service-account.json
@@ -1,4 +1,0 @@
-{
-  "create_service_account": "",
-  "service_accounts_small": ""
-}

--- a/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTab.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTab.tsx
@@ -71,7 +71,7 @@ export const KafkaConnectionTab: FunctionComponent<KafkaConnectionTabProps> = ({
       </TextContent>
       <TextContent className="pf-u-pb-sm">
         <Text component={TextVariants.h3} className="pf-u-mt-xl">
-          {t("service-account:service_accounts_small")}
+          {t("kafka:connection_tab.service_accounts_small")}
         </Text>
         <Text component={TextVariants.small}>
           {
@@ -91,7 +91,7 @@ export const KafkaConnectionTab: FunctionComponent<KafkaConnectionTabProps> = ({
         isInline
         onClick={showCreateServiceAccountModal}
       >
-        {t("service-account:create_service_account")}
+        {t("kafka:connection_tab.create_service_account")}
       </Button>
       <TextContent className="pf-u-pt-sm">
         <Text component={TextVariants.small}>

--- a/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTabP2.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTabP2.tsx
@@ -77,7 +77,7 @@ export const KafkaConnectionTabP2: FunctionComponent<
       </TextContent>
       <TextContent className="pf-u-pb-sm">
         <Text component={TextVariants.h3} className="pf-u-mt-xl">
-          {t("service-account:service_accounts_small")}
+          {t("connection-tab:service_accounts_small")}
         </Text>
         <Text component={TextVariants.small}>
           {
@@ -97,7 +97,7 @@ export const KafkaConnectionTabP2: FunctionComponent<
         isInline
         onClick={showCreateServiceAccountModal}
       >
-        {t("service-account:create_service_account")}
+        {t("connection-tab:create_service_account")}
       </Button>
       <TextContent className="pf-u-pt-sm">
         <Text component={TextVariants.small}>

--- a/src/Kafka/ServiceAccount/components/ServiceAccountToolbar.tsx
+++ b/src/Kafka/ServiceAccount/components/ServiceAccountToolbar.tsx
@@ -87,7 +87,7 @@ export const ServiceAccountToolbar: VoidFunctionComponent<
         <ToolbarGroup>
           <ToolbarItem>
             <Button variant={"primary"} onClick={onCreateServiceAccountClick}>
-              {t("service-account:create_service_account")}
+              {t("connection-tab:create_service_account")}
             </Button>
           </ToolbarItem>
         </ToolbarGroup>

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -26,8 +26,6 @@ const AllTheProviders: FunctionComponent = ({ children }) => {
             apimgmtoverview: () => import("../locales/en/apimgmtoverview.json"),
             "manage-kafka-permissions": () =>
               import("../locales/en/manage-kafka-permissions.json"),
-            "service-account": () =>
-              import("../locales/en/service-account.json"),
             "message-browser": () =>
               import("../locales/en/message-browser.json"),
             "overview-v2": () => import("../locales/en/overview-v2.json"),


### PR DESCRIPTION
**What this PR does / why we need it**:

> Moving the strings in the service account translation file to the Kafka file, since the strings are related to KafkaConnectionTab.

