### PR TITLE
chore: Creating new prop to handle admin server url

### DIFF
--- a/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTab.stories.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTab.stories.tsx
@@ -27,11 +27,13 @@ const Template: ComponentStory<typeof KafkaConnectionTab> = (args) => (
 export const ConnectionTab = Template.bind({});
 ConnectionTab.args = {
   isKafkaPending: false,
+  isAdminUrlUndefined: false,
 };
 
 export const ConnectionTabWhenkafkaCreationPending = Template.bind({});
 ConnectionTabWhenkafkaCreationPending.args = {
   isKafkaPending: true,
+  isAdminUrlUndefined: true,
 };
 ConnectionTabWhenkafkaCreationPending.storyName =
   "Connection tab when Kafka Creation pending";

--- a/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTab.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTab.tsx
@@ -25,6 +25,7 @@ export type KafkaConnectionTabProps = {
   adminAPIUrl: string;
   showCreateServiceAccountModal: () => void;
   kafkaFleetManagerUrl: string;
+  isAdminUrlUndefined?: boolean;
 };
 
 export const KafkaConnectionTab: FunctionComponent<KafkaConnectionTabProps> = ({
@@ -36,6 +37,7 @@ export const KafkaConnectionTab: FunctionComponent<KafkaConnectionTabProps> = ({
   adminAPIUrl,
   kafkaFleetManagerUrl,
   showCreateServiceAccountModal,
+  isAdminUrlUndefined,
 }) => {
   const { t } = useTranslation();
 
@@ -147,7 +149,7 @@ export const KafkaConnectionTab: FunctionComponent<KafkaConnectionTabProps> = ({
               </Button>
             </Popover>
           </strong>
-          {isKafkaPending ? (
+          {isAdminUrlUndefined ? (
             <Skeleton fontSize="2xl" />
           ) : (
             <ClipboardCopy

--- a/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTabP2.stories.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTabP2.stories.tsx
@@ -28,11 +28,13 @@ const Template: ComponentStory<typeof KafkaConnectionTabP2> = (args) => (
 export const ConnectionTab = Template.bind({});
 ConnectionTab.args = {
   isKafkaPending: false,
+  isAdminUrlUndefined: false,
 };
 
 export const ConnectionTabWhenkafkaCreationPending = Template.bind({});
 ConnectionTabWhenkafkaCreationPending.args = {
   isKafkaPending: true,
+  isAdminUrlUndefined: true,
 };
 ConnectionTabWhenkafkaCreationPending.storyName =
   "Connection tab when Kafka Creation pending";

--- a/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTabP2.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaConnectionTabP2.tsx
@@ -28,6 +28,7 @@ export type KafkaConnectionTabP2Props = {
   showCreateServiceAccountModal: () => void;
   kafkaFleetManagerUrl: string;
   linkToDocPortal: string;
+  isAdminUrlUndefined?: boolean;
 };
 
 export const KafkaConnectionTabP2: FunctionComponent<
@@ -42,6 +43,7 @@ export const KafkaConnectionTabP2: FunctionComponent<
   kafkaFleetManagerUrl,
   showCreateServiceAccountModal,
   linkToDocPortal,
+  isAdminUrlUndefined,
 }) => {
   const { t } = useTranslation();
 
@@ -172,7 +174,7 @@ export const KafkaConnectionTabP2: FunctionComponent<
                 </Button>
               </Popover>
             </strong>
-            {isKafkaPending ? (
+            {isAdminUrlUndefined ? (
               <Skeleton fontSize="2xl" />
             ) : (
               <ClipboardCopy


### PR DESCRIPTION
**What this PR does / why we need it**:

> Admin server Url will be undefined until the Kafka instance is ready,  so creating a new prop to handle the scenario 

