### PR TITLE
fix(ExternalLink): make className prop optional

### DIFF
--- a/src/shared/ExternalLink/ExternalLink.tsx
+++ b/src/shared/ExternalLink/ExternalLink.tsx
@@ -7,7 +7,7 @@ export type ExternaLinkProps = {
   testId: string;
   target?: ButtonProps["target"];
   href: NonNullable<ButtonProps["href"]>;
-  className: string;
+  className?: string;
 };
 
 export const ExternalLink: FunctionComponent<ExternaLinkProps> = ({


### PR DESCRIPTION
**What this PR does / why we need it**:

makes the ExternalLink `className` prop optional.

cc @riccardo-forina 
