### PR TITLE
fix: Prevent focus to change on clicking row kebab options

### DIFF
--- a/src/shared/Table/ResponsiveTable.test.tsx
+++ b/src/shared/Table/ResponsiveTable.test.tsx
@@ -27,8 +27,11 @@ describe("ResponsiveTable", () => {
     expect(comp.queryAllByLabelText("Actions")).toHaveLength(
       sampleData.length - 1 /* deleted lines don't have actions */
     );
-
+    const actions = comp.queryAllByTestId("kebab-options");
+    userEvent.click(actions[0]);
+    expect(clickSpy).not.toHaveBeenCalled();
     userEvent.click(comp.getByText(sampleData[0][0]));
+
     expect(clickSpy).toHaveBeenNthCalledWith(1, {
       row: sampleData[0],
       rowIndex: 0,

--- a/src/shared/Table/ResponsiveTable.tsx
+++ b/src/shared/Table/ResponsiveTable.tsx
@@ -204,6 +204,7 @@ export const ResponsiveTable = <TRow, TCol>({
               columnWidth={minimumColumnWidth}
               canHide={false}
               isActionCell={true}
+              onClick={(event) => event.stopPropagation()}
             >
               {renderActions({ rowIndex, row, ActionsColumn })}
             </ResponsiveTd>

--- a/src/shared/Table/ResponsiveTable.tsx
+++ b/src/shared/Table/ResponsiveTable.tsx
@@ -205,6 +205,7 @@ export const ResponsiveTable = <TRow, TCol>({
               canHide={false}
               isActionCell={true}
               onClick={(event) => event.stopPropagation()}
+              data-testid={"kebab-options"}
             >
               {renderActions({ rowIndex, row, ActionsColumn })}
             </ResponsiveTd>


### PR DESCRIPTION
Signed-off-by: suyash-naithani <suyash.naithani@gmail.com>

**What this PR does / why we need it**:

> This PR prevents the onClick handler to be called when clicking on a row kebab option, thus making sure the focus on a row does not change

**Which issue(s) this PR fixes** 

> Fixes [#168](https://issues.redhat.com/browse/MGDX-168)

