### PR TITLE
feat: add a way to set the ouia id for the action cell in ResponsiveTable

### DIFF
--- a/src/shared/Table/ResponsiveTable.stories.tsx
+++ b/src/shared/Table/ResponsiveTable.stories.tsx
@@ -25,6 +25,7 @@ const eventsFromNames = actions("onRowClick");
 const ResponsiveTableSampleType: VoidFunctionComponent<
   ResponsiveTableProps<SampleDataType, typeof columns[number]> & {
     hasActions?: boolean;
+    hasCustomActionTestId?: boolean;
     isRowClickable?: boolean;
     selectedRow?: number;
   }
@@ -38,6 +39,7 @@ export default {
     data: sampleData,
     columns,
     hasActions: true,
+    hasCustomActionTestId: false,
     isRowClickable: true,
     selectedRow: 3,
     expectedLength: 3,
@@ -76,6 +78,11 @@ const Template: ComponentStory<typeof ResponsiveTableSampleType> = (args) => (
     }
     isRowDeleted={({ row }) => row[5] === deletingSign}
     onRowClick={args.onRowClick || eventsFromNames["onRowClick"]}
+    setActionCellOuiaId={
+      args.hasCustomActionTestId
+        ? ({ rowIndex }) => `my-action-row-${rowIndex}`
+        : undefined
+    }
   >
     <EmptyState variant={EmptyStateVariant.large}>
       <EmptyStateIcon icon={InfoIcon} />
@@ -116,4 +123,9 @@ UndefinedDataShowsSkeleton.args = {
 export const NoResults = Template.bind({});
 NoResults.args = {
   data: [],
+};
+
+export const CustomActionTestId = Template.bind({});
+CustomActionTestId.args = {
+  hasCustomActionTestId: true,
 };

--- a/src/shared/Table/ResponsiveTable.test.tsx
+++ b/src/shared/Table/ResponsiveTable.test.tsx
@@ -10,6 +10,7 @@ const {
   UndefinedDataShowsSkeleton,
   WithoutActions,
   NoResults,
+  CustomActionTestId,
 } = composeStories(stories);
 
 describe("ResponsiveTable", () => {
@@ -27,7 +28,7 @@ describe("ResponsiveTable", () => {
     expect(comp.queryAllByLabelText("Actions")).toHaveLength(
       sampleData.length - 1 /* deleted lines don't have actions */
     );
-    const actions = comp.queryAllByTestId("kebab-options");
+    const actions = comp.queryAllByTestId("actions-for-row-0");
     userEvent.click(actions[0]);
     expect(clickSpy).not.toHaveBeenCalled();
     userEvent.click(comp.getByText(sampleData[0][0]));
@@ -64,5 +65,10 @@ describe("ResponsiveTable", () => {
   it("works without specifying renderActions", () => {
     const comp = render(<WithoutActions />);
     expect(comp.queryAllByLabelText("Actions")).toHaveLength(0);
+  });
+
+  it("can use a custom test id for actions", () => {
+    const comp = render(<CustomActionTestId />);
+    expect(comp.queryAllByTestId("my-action-row-0")).toHaveLength(1);
   });
 });

--- a/src/shared/Table/ResponsiveTable.tsx
+++ b/src/shared/Table/ResponsiveTable.tsx
@@ -58,6 +58,7 @@ export type ResponsiveTableProps<TRow, TCol> = {
   isRowSelected?: (props: RowProps<TRow>) => boolean;
   expectedLength?: number;
   onRowClick?: (props: RowProps<TRow>) => void;
+  setActionCellOuiaId?: (props: RowProps<TRow>) => string;
 };
 
 type RowProps<TRow> = { row: TRow; rowIndex: number };
@@ -74,6 +75,7 @@ export const ResponsiveTable = <TRow, TCol>({
   isRowSelected,
   expectedLength = 3,
   onRowClick,
+  setActionCellOuiaId,
   children,
 }: PropsWithChildren<ResponsiveTableProps<TRow, TCol>>) => {
   const [width, setWidth] = useState(1000);
@@ -205,7 +207,11 @@ export const ResponsiveTable = <TRow, TCol>({
               canHide={false}
               isActionCell={true}
               onClick={(event) => event.stopPropagation()}
-              data-testid={"kebab-options"}
+              data-testid={
+                setActionCellOuiaId
+                  ? setActionCellOuiaId({ row, rowIndex })
+                  : `actions-for-row-${rowIndex}`
+              }
             >
               {renderActions({ rowIndex, row, ActionsColumn })}
             </ResponsiveTd>


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds a customizer function to ResponsiveTable so a consumer can
customize the test ID attribute for the actions kebab.  It also updates
the default test ID used so that rows can be selected by index.

**Special notes for your reviewer**:
I've left the return type of the customizer function constrained to just what I need, but maybe there's a better option.  Also I'm meh on the function name, so any suggestions are welcome :-)