### PR TITLE
fix: make the billing popover show a title, and make the link not external

### DIFF
--- a/src/Kafka/CreateKafkaInstance/Stories/storiesHelpers.tsx
+++ b/src/Kafka/CreateKafkaInstance/Stories/storiesHelpers.tsx
@@ -479,7 +479,7 @@ export const defaultStoryArgs: StoryProps = {
     action("onCreate")(_data);
     setTimeout(onSuccess, 500);
   },
-  subscriptionOptionsHref: "https://www.redhat.com",
+  subscriptionOptionsHref: "/../overview",
 };
 
 export type StoryMeta = Meta<StoryProps>;

--- a/src/Kafka/CreateKafkaInstance/components/BillingHelp.tsx
+++ b/src/Kafka/CreateKafkaInstance/components/BillingHelp.tsx
@@ -2,7 +2,7 @@ import { Popover } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import type { VoidFunctionComponent } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { ExternalLink } from "../../../shared";
+import { Link } from "react-router-dom";
 
 export type BillingHelpProps = {
   type: "rh-only" | "external-marketplaces";
@@ -17,6 +17,7 @@ export const BillingHelp: VoidFunctionComponent<BillingHelpProps> = ({
   return (
     <Popover
       aria-label={t("billing.field_label")}
+      headerContent={t("billing.field_label")}
       bodyContent={
         <Trans
           i18nKey={
@@ -25,12 +26,7 @@ export const BillingHelp: VoidFunctionComponent<BillingHelpProps> = ({
               : "billing.field_popover_external_marketplace"
           }
           ns={"create-kafka-instance"}
-          components={[
-            <ExternalLink
-              testId={"subscription-options-ext-link"}
-              href={subscriptionOptionsHref}
-            />,
-          ]}
+          components={[<Link to={subscriptionOptionsHref} />]}
         />
       }
     >


### PR DESCRIPTION
**What this PR does / why we need it**:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/966316/183094079-345ae61b-04c7-463b-9da6-cc18d443bea2.png">

Added the title to the popover, and made the link not external.