### PR TITLE
fix: specify the pagination variants

### DIFF
--- a/src/shared/Table/TableView.tsx
+++ b/src/shared/Table/TableView.tsx
@@ -43,6 +43,7 @@ export const TableView = <TRow, TCol>({
                   page={page}
                   perPage={perPage}
                   onChange={onPageChange}
+                  variant={"top"}
                   isCompact
                 />
               </ToolbarGroup>
@@ -54,18 +55,13 @@ export const TableView = <TRow, TCol>({
         <ResponsiveTable {...tableProps} />
       </InnerScrollContainer>
       {showPagination && (
-        <Toolbar>
-          <ToolbarContent>
-            <ToolbarGroup alignment={{ default: "alignRight" }}>
-              <Pagination
-                itemCount={itemCount}
-                page={page}
-                perPage={perPage}
-                onChange={onPageChange}
-              />
-            </ToolbarGroup>
-          </ToolbarContent>
-        </Toolbar>
+        <Pagination
+          itemCount={itemCount}
+          page={page}
+          perPage={perPage}
+          variant={"bottom"}
+          onChange={onPageChange}
+        />
       )}
     </OuterScrollContainer>
   );


### PR DESCRIPTION

**What this PR does / why we need it**:

This change ensures that the pagination navigation is available in
smaller screen widths by specifying the appropriate variant to the
pagination control.  It also removes the toolbar wrapping the pagination
component as it prevents the pagination control from appearing correctly
in narrow widths.

**Which issue(s) this PR fixes** 

The bug in action (yes I like loud backgrounds):

![image](https://user-images.githubusercontent.com/351660/185423797-4b99a2ad-d3e7-4f7d-acef-560002f5c88f.png)

with this fix applied in storybook:

![image](https://user-images.githubusercontent.com/351660/185424026-f716e764-f380-4f14-bcac-82dd029a453f.png)
