### PR TITLE
chore: Add data-testid for select and dropdown component in kafka message browser

### DIFF
--- a/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
@@ -49,9 +49,13 @@ export const FilterGroup: VoidFunctionComponent<FilterGroupProps> = ({
     <ToolbarItem>
       <InputGroup>
         <Dropdown
-          data-testid={"filter-group"}
+          data-testid={"filter-group-dropdown"}
           toggle={
-            <DropdownToggle onToggle={setIsOpen} isDisabled={isDisabled}>
+            <DropdownToggle
+              onToggle={setIsOpen}
+              isDisabled={isDisabled}
+              data-testid={"filter-group"}
+            >
               {labels[currentCategory]}
             </DropdownToggle>
           }

--- a/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/FilterGroup.tsx
@@ -49,12 +49,9 @@ export const FilterGroup: VoidFunctionComponent<FilterGroupProps> = ({
     <ToolbarItem>
       <InputGroup>
         <Dropdown
+          data-testid={"filter-group"}
           toggle={
-            <DropdownToggle
-              onToggle={setIsOpen}
-              isDisabled={isDisabled}
-              data-testid={"filter-group"}
-            >
+            <DropdownToggle onToggle={setIsOpen} isDisabled={isDisabled}>
               {labels[currentCategory]}
             </DropdownToggle>
           }

--- a/src/Kafka/KafkaMessageBrowser/components/LimitSelector.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/LimitSelector.tsx
@@ -40,6 +40,7 @@ export const LimitSelector: VoidFunctionComponent<LimitSelectorProps> = ({
           isOpen={isOpen}
           isDisabled={isDisabled}
           onSelect={() => setIsOpen(false)}
+          data-testid={"limit-selector"}
         >
           {[10, 20, 50].map((value, idx) => (
             <SelectOption

--- a/src/Kafka/KafkaMessageBrowser/components/PartitionSelector.tsx
+++ b/src/Kafka/KafkaMessageBrowser/components/PartitionSelector.tsx
@@ -106,6 +106,7 @@ export const PartitionSelector: VoidFunctionComponent<
           isDisabled={isDisabled}
           placeholderText={t("partition_placeholder")}
           onClear={() => onChange(undefined)}
+          data-testid={"partition-selector"}
         >
           {options}
         </Select>


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:
Add data-testid for select and dropdown component in kafka message browser

**Which issue(s) this PR fixes** 
> Add data-testid as per the QE request 

