### PR TITLE
chore: Add kafka version property to the kafka details tab

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -39,6 +39,7 @@
   "kafka": "Kafka",
   "kafka_instance": "$t(common:kafka) Instances",
   "kafka_instance_name": "$t(common:kafka) instance name",
+  "kafka_version": "Kafka version",
   "loading": "Loading",
   "mvn": "mvn",
   "name": "Name",

--- a/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.stories.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.stories.tsx
@@ -28,6 +28,7 @@ export default {
     connectionRate: 100,
     messageSize: 1,
     billing: "prepaid",
+    kafkaVersion: "3.0.1",
   },
   argTypes: {
     billing: {

--- a/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.tsx
@@ -34,6 +34,7 @@ export type KafkaDetailsTabProps = {
   connectionRate: number | undefined;
   messageSize: number | undefined;
   billing: "prepaid" | MarketplaceSubscription | undefined;
+  kafkaVersion: string;
 };
 
 export const KafkaDetailsTab: VoidFunctionComponent<KafkaDetailsTabProps> = ({
@@ -53,6 +54,7 @@ export const KafkaDetailsTab: VoidFunctionComponent<KafkaDetailsTabProps> = ({
   connectionRate,
   messageSize,
   billing,
+  kafkaVersion,
 }) => {
   const { t } = useTranslation("kafka");
 
@@ -145,6 +147,7 @@ export const KafkaDetailsTab: VoidFunctionComponent<KafkaDetailsTabProps> = ({
           )}
 
           {renderTextListItem(t("common:id"), id)}
+          {renderTextListItem(t("common:kafka_version"), kafkaVersion)}
           {renderTextListItem(t("common:owner"), owner)}
           {renderTextListItem(
             t("common:time_created"),

--- a/src/Kafka/KafkaInstanceDrawer/__snapshots__/KafkaDetailsTab.test.tsx.snap
+++ b/src/Kafka/KafkaInstanceDrawer/__snapshots__/KafkaDetailsTab.test.tsx.snap
@@ -125,6 +125,18 @@ exports[`Details Tab renders standard instance 1`] = `
             class=""
             data-pf-content="true"
           >
+            Kafka version
+          </dt>
+          <dd
+            class=""
+            data-pf-content="true"
+          >
+            3.0.1
+          </dd>
+          <dt
+            class=""
+            data-pf-content="true"
+          >
             Owner
           </dt>
           <dd


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

>Add kafka version property to the kafka details tab

**Which issue(s) this PR fixes** 

fixes https://issues.redhat.com/browse/MGDSTRM-9152

**Verification steps** 
https://619e1921b3e38b003afeb2be-vphlcabiyg.chromatic.com/?path=/story/kafka-kafkainstancedrawer-kafkadetailstab--standard-instance-created