### PR TITLE
chore: add types to index.tsx file

### DIFF
--- a/src/Kafka/index.ts
+++ b/src/Kafka/index.ts
@@ -7,3 +7,4 @@ export * from "./Metrics";
 export * from "./ServiceAccount";
 export * from "./ConsumerGroups";
 export * from "./Settings";
+export * from "./types";


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

> While updating the version of app-services-ui-component in kas-ui, I noticed that some of the types are defined in the types.ts file is used in kas-ui, since it's not exported it's not available in the kas-ui


