### PR TITLE
chore: re-export react-i18next 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ module.exports = () => {
             singleton: true,
             requiredVersion: peerDependencies['react-dom'],
           },
-          'react-i18next': {
-            singleton: true,
-            requiredVersion: peerDependencies['react-i18next'],
-          },
           'react-router-dom': {
             singleton: true,
             requiredVersion: peerDependencies['react-router-dom'],
@@ -86,6 +82,26 @@ module.exports = () => {
   };
 }
 ```
+
+## i18n
+This project implements i18n using `react-i18next`. 
+
+You can translate strings by using one of the methods provided by `react-18next`, like the [`useTranslation`](https://react.i18next.com/latest/usetranslation-hook) hook.
+
+To make life easier when developing a new Managed Application Services UI or when writing unit tests that also cover translations, the whole `react-i18next` library is re-exported by `@rhoas/app-services-ui-components`.
+
+You can translate your content without directly including `react-i18next` as a direct dependency of your project by doing:
+
+```tsx
+import { useTranslation } from '@rhoas/app-services-ui-components';
+
+const MyComponent = () => {
+    const { t } = useTranslation();
+    return <span>{t('common:status')}</span>
+}
+```
+
+Refer to the `react-i18next` [documentation](https://react.i18next.com/) for more information.
 
 ## Optional: set up the shared context providers
 

--- a/src/I18n/I18nProvider.tsx
+++ b/src/I18n/I18nProvider.tsx
@@ -22,3 +22,5 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
     {children}
   </I18nextProvider>
 );
+
+export * from "react-i18next";


### PR DESCRIPTION
**What this PR does / why we need it**:

We are currently required to install `react-i18next` as a dependency of our MAS UI projects in order to translate content.

This will frequently produce two different versions of the same package in the dependency tree, like:

```
├─┬ @rhoas/app-services-ui-components@1.40.6
│ └── react-i18next@11.17.3
└── react-i18next@11.18.5
```

`I18nProvider` and `useTranslation` will then come from different versions. The result is unit tests will start failing, they will not be able to translate strings anymore.
 
One possible solution is to re-export `react-i18next` from `app-services-ui-components`.

This way it will live only here. Other UI projects will not have to include `react-i18next` as a dependency. Instead they will import everything from `app-services-ui-components`, both i18n providers and translation functions.

There are other ways to fix this issue but I guess re-exporting is the simpler one.

It's been a while since we last discussed this issue. Let me know what you think or if there are different plans about how to sort things out.