### PR TITLE
feat: UI components when the kafka instance is suspended

### DIFF
--- a/locales/en/kafka.json
+++ b/locales/en/kafka.json
@@ -177,6 +177,11 @@
   },
   "storage": "Storage",
   "storage_value": "up to 1000 GiB",
+  "suspend_empty_state_body": "Most actions are unavailable with a suspended instance.",
+  "suspend_empty_state_title": "This instance is suspended",
+  "suspend_popover_body_1": "The subscription associated with this instance is no longer active.",
+  "suspend_popover_body_2": "Learn more about suspended instances",
+  "suspend_popover_title": "Suspended instance",
   "table": {
     "actions": {
       "change-owner": "Change owner",

--- a/src/Kafka/KafkaInstanceDrawer/components/SuspendConnection.stories.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/components/SuspendConnection.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { SuspendConnection } from "./SuspendConnection";
+
+export default {
+  component: SuspendConnection,
+  args: {},
+  parameters: {
+    backgrounds: {
+      default: "Background color 100",
+    },
+  },
+} as ComponentMeta<typeof SuspendConnection>;
+
+const Template: ComponentStory<typeof SuspendConnection> = (args) => (
+  <SuspendConnection {...args} />
+);
+
+export const SuspendedConnectionEmptyState = Template.bind({});

--- a/src/Kafka/KafkaInstanceDrawer/components/SuspendConnection.test.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/components/SuspendConnection.test.tsx
@@ -1,0 +1,13 @@
+import { render, waitForI18n } from "../../../test-utils";
+import { composeStories } from "@storybook/testing-react";
+import * as stories from "./SuspendConnection.stories";
+
+const { SuspendedConnectionEmptyState } = composeStories(stories);
+
+describe("Consumer Group empty state", () => {
+  it("renders", async () => {
+    const comp = render(<SuspendedConnectionEmptyState />);
+    await waitForI18n(comp);
+    expect(comp.baseElement).toMatchSnapshot();
+  });
+});

--- a/src/Kafka/KafkaInstanceDrawer/components/SuspendConnection.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/components/SuspendConnection.tsx
@@ -1,0 +1,24 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+  TitleSizes,
+} from "@patternfly/react-core";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import type { VoidFunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+
+export const SuspendConnection: VoidFunctionComponent = () => {
+  const { t } = useTranslation("kafka");
+  return (
+    <EmptyState variant={EmptyStateVariant.large}>
+      <EmptyStateIcon icon={ExclamationTriangleIcon} color={"#f0ab00"} />
+      <Title headingLevel={"h1"} size={TitleSizes.lg}>
+        {t("suspend_empty_state_title")}
+      </Title>
+      <EmptyStateBody>{t("suspend_empty_state_body")}</EmptyStateBody>
+    </EmptyState>
+  );
+};

--- a/src/Kafka/KafkaInstanceDrawer/components/SuspendPopover.stories.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/components/SuspendPopover.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { SuspendPopover } from "./SuspendPopover";
+
+export default {
+  component: SuspendPopover,
+  args: {},
+  parameters: {
+    backgrounds: {
+      default: "Background color 100",
+    },
+  },
+} as ComponentMeta<typeof SuspendPopover>;
+
+const Template: ComponentStory<typeof SuspendPopover> = (args) => (
+  <SuspendPopover {...args} />
+);
+
+export const Popover = Template.bind({});

--- a/src/Kafka/KafkaInstanceDrawer/components/SuspendPopover.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/components/SuspendPopover.tsx
@@ -1,0 +1,33 @@
+import {
+  Button,
+  ButtonVariant,
+  Popover,
+  TextContent,
+} from "@patternfly/react-core";
+import type { VoidFunctionComponent } from "react";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { useTranslation } from "react-i18next";
+import { ExternalLink } from "../../../shared";
+
+export const SuspendPopover: VoidFunctionComponent = () => {
+  const { t } = useTranslation("kafka");
+  return (
+    <Popover
+      alertSeverityVariant={"warning"}
+      headerIcon={<ExclamationTriangleIcon />}
+      headerContent={t("suspend_popover_title")}
+      bodyContent={
+        <TextContent>
+          <p>{t("suspend_popover_body_1")}</p>
+          <p>
+            <ExternalLink testId={"suspended-instance-button"} href={"#"}>
+              {t("suspend_popover_body_2")}
+            </ExternalLink>
+          </p>
+        </TextContent>
+      }
+    >
+      <Button variant={ButtonVariant.link}>{"Suspended"}</Button>
+    </Popover>
+  );
+};

--- a/src/Kafka/KafkaInstanceDrawer/components/__snapshots__/SuspendConnection.test.tsx.snap
+++ b/src/Kafka/KafkaInstanceDrawer/components/__snapshots__/SuspendConnection.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Consumer Group empty state renders 1`] = `
+<body>
+  <div>
+    <div
+      class="pf-c-empty-state pf-m-lg"
+    >
+      <div
+        class="pf-c-empty-state__content"
+      >
+        <svg
+          aria-hidden="true"
+          class="pf-c-empty-state__icon"
+          fill="#f0ab00"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 576 512"
+          width="1em"
+        >
+          <path
+            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+          />
+        </svg>
+        <h1
+          class="pf-c-title pf-m-lg"
+          data-ouia-component-id="OUIA-Generated-Title-1"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe="true"
+        >
+          This instance is suspended
+        </h1>
+        <div
+          class="pf-c-empty-state__body"
+        >
+          Most actions are unavailable with a suspended instance.
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <ul
+      aria-atomic="false"
+      aria-live="polite"
+      class="pf-c-alert-group pf-m-toast"
+    />
+  </div>
+</body>
+`;


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

> Create UI components to communicate the Kafka instance is suspended

**Which issue(s) this PR fixes** 

> Replace this comment with references to related issues.
fixes https://issues.redhat.com/browse/MGDSTRM-9745


