### PR TITLE
feat: provide configurability for ouia ids of table and table rows elements in ResponsiveTable

### DIFF
--- a/src/shared/Table/ResponsiveTable.stories.tsx
+++ b/src/shared/Table/ResponsiveTable.stories.tsx
@@ -26,6 +26,7 @@ const ResponsiveTableSampleType: VoidFunctionComponent<
   ResponsiveTableProps<SampleDataType, typeof columns[number]> & {
     hasActions?: boolean;
     hasCustomActionTestId?: boolean;
+    hasCustomOuiaIds?: boolean;
     isRowClickable?: boolean;
     isSortable?: boolean;
     sortAllColumns?: boolean;
@@ -42,6 +43,7 @@ export default {
     columns,
     hasActions: true,
     hasCustomActionTestId: false,
+    hasCustomOuiaIds: false,
     isRowClickable: true,
     isSortable: false,
     sortAllColumns: true,
@@ -104,6 +106,12 @@ const Template: ComponentStory<typeof ResponsiveTableSampleType> = (args) => {
           ? ({ rowIndex }) => `my-action-row-${rowIndex}`
           : undefined
       }
+      setRowOuiaId={
+        args.hasCustomOuiaIds
+          ? ({ rowIndex }) => `table-row-${rowIndex}`
+          : undefined
+      }
+      tableOuiaId={args.hasCustomOuiaIds ? "table-ouia-id" : undefined}
     >
       <EmptyState variant={EmptyStateVariant.large}>
         <EmptyStateIcon icon={InfoIcon} />
@@ -150,6 +158,11 @@ NoResults.args = {
 export const CustomActionTestId = Template.bind({});
 CustomActionTestId.args = {
   hasCustomActionTestId: true,
+};
+
+export const CustomOuiaIds = Template.bind({});
+CustomOuiaIds.args = {
+  hasCustomOuiaIds: true,
 };
 
 export const Sortable = Template.bind({});

--- a/src/shared/Table/ResponsiveTable.test.tsx
+++ b/src/shared/Table/ResponsiveTable.test.tsx
@@ -11,6 +11,7 @@ const {
   WithoutActions,
   NoResults,
   CustomActionTestId,
+  CustomOuiaIds,
 } = composeStories(stories);
 
 describe("ResponsiveTable", () => {
@@ -69,5 +70,19 @@ describe("ResponsiveTable", () => {
   it("can use a custom test id for actions", () => {
     const comp = render(<CustomActionTestId />);
     expect(comp.queryAllByTestId("my-action-row-0")).toHaveLength(1);
+  });
+
+  it("can use custom ouia ids for both table, and table rows elements", () => {
+    const comp = render(<CustomOuiaIds />);
+    expect(
+      comp.baseElement.querySelectorAll(
+        "[data-ouia-component-id='table-ouia-id']"
+      )
+    ).toHaveLength(1);
+    expect(
+      comp.baseElement.querySelectorAll(
+        "[data-ouia-component-id='table-row-0']"
+      )
+    ).toHaveLength(1);
   });
 });

--- a/src/shared/Table/ResponsiveTable.tsx
+++ b/src/shared/Table/ResponsiveTable.tsx
@@ -62,6 +62,8 @@ export type ResponsiveTableProps<TRow, TCol> = {
   expectedLength?: number;
   onRowClick?: (props: RowProps<TRow>) => void;
   setActionCellOuiaId?: (props: RowProps<TRow>) => string;
+  setRowOuiaId?: (props: RowProps<TRow>) => string;
+  tableOuiaId?: string;
 };
 
 type RowProps<TRow> = { row: TRow; rowIndex: number };
@@ -80,6 +82,8 @@ export const ResponsiveTable = <TRow, TCol>({
   expectedLength = 3,
   onRowClick,
   setActionCellOuiaId,
+  setRowOuiaId,
+  tableOuiaId,
   children,
 }: PropsWithChildren<ResponsiveTableProps<TRow, TCol>>) => {
   const [width, setWidth] = useState(1000);
@@ -179,6 +183,7 @@ export const ResponsiveTable = <TRow, TCol>({
       gridBreakPoint=""
       ref={ref}
       className={showColumns ? "" : "pf-m-grid"}
+      ouiaId={tableOuiaId}
     >
       <Thead>
         <Tr>{header}</Tr>
@@ -235,6 +240,7 @@ export const ResponsiveTable = <TRow, TCol>({
               isDeleted={deleted}
               isSelected={selected}
               onClick={onClick}
+              rowOuiaId={setRowOuiaId?.({ row, rowIndex })}
             >
               {cells}
               {action}
@@ -325,9 +331,10 @@ export type DeletableRowProps = {
   isSelected: boolean;
   isDeleted: boolean;
   onClick?: () => void;
+  rowOuiaId?: string;
 };
 export const DeletableRow: FunctionComponent<DeletableRowProps> = memo(
-  ({ isDeleted, isSelected, onClick, children }) => {
+  ({ isDeleted, isSelected, onClick, children, rowOuiaId }) => {
     return (
       <Tr
         isHoverable={!isDeleted && onClick !== undefined}
@@ -338,6 +345,7 @@ export const DeletableRow: FunctionComponent<DeletableRowProps> = memo(
             }
           }
         }}
+        ouiaId={rowOuiaId}
         isRowSelected={isSelected}
         className={isDeleted ? "mas--ResponsiveTable__Tr--deleted" : undefined}
         data-testid={[isSelected && "row-selected", isDeleted && "row-deleted"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds two new properties in the `ResponsiveTable` component for setting custom ouiaIds for `<table>` and `<tr>`s elements

**Verification steps** 

You can see in the DOM that the `data-ouia-component-id` attributes will be set as specified.
![image](https://user-images.githubusercontent.com/22591802/200346172-b94bfe32-ac92-4ca0-bcb3-262f8fca0776.png)
