### PR TITLE
chore: Remove async call for acl topics

### DIFF
--- a/src/Kafka/ManageKafkaPermissions/ManageKafkaPermissions.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/ManageKafkaPermissions.stories.tsx
@@ -6,39 +6,20 @@ import {
   PermissionsForAllAccounts,
   PermissionsForSelectedAccount,
 } from "./components/ReviewPermissionsTable.stories";
-import { fakeApi } from "../../shared/storiesHelpers";
-
 export default {
   component: ManageKafkaPermissions,
   args: {
-    resourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
-    fetchConsumeTopicShortcutResourceName: (filter) =>
-      fakeApi<string[]>(
-        ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
-    onFetchConsumeTopicShortcutTopicResourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
-    onFetchProduceTopicShortcutResourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
+    topicNameOptions: (filter: string) => {
+      return ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
+        v.includes(filter)
+      );
+    },
+    consumerGroupNameOptions: (filter: string) => {
+      return ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
+        v.includes(filter)
+      );
+    },
+
     accounts: [
       {
         id: "id",

--- a/src/Kafka/ManageKafkaPermissions/ManageKafkaPermissions.tsx
+++ b/src/Kafka/ManageKafkaPermissions/ManageKafkaPermissions.tsx
@@ -34,14 +34,8 @@ export type ManageKafkaPermissionsProps = {
   onRemoveAcls: (index: number) => void;
   selectedAccount: string | undefined;
   onChangeSelectedAccount: (value: string | undefined) => void;
-  resourceNameOptions: (filter: string) => Promise<string[]>;
-  fetchConsumeTopicShortcutResourceName: (filter: string) => Promise<string[]>;
-  onFetchConsumeTopicShortcutTopicResourceNameOptions: (
-    filter: string
-  ) => Promise<string[]>;
-  onFetchProduceTopicShortcutResourceNameOptions: (
-    filter: string
-  ) => Promise<string[]>;
+  topicNameOptions: (filter: string) => string[];
+  consumerGroupNameOptions: (filter: string) => string[];
 };
 
 export const ManageKafkaPermissions: React.FC<ManageKafkaPermissionsProps> = ({
@@ -53,10 +47,8 @@ export const ManageKafkaPermissions: React.FC<ManageKafkaPermissionsProps> = ({
   onSave,
   selectedAccount,
   onChangeSelectedAccount,
-  resourceNameOptions,
-  fetchConsumeTopicShortcutResourceName,
-  onFetchConsumeTopicShortcutTopicResourceNameOptions,
-  onFetchProduceTopicShortcutResourceNameOptions,
+  topicNameOptions,
+  consumerGroupNameOptions,
 }) => {
   const { t } = useTranslation([
     "manage-kafka-permissions",
@@ -291,19 +283,8 @@ export const ManageKafkaPermissions: React.FC<ManageKafkaPermissionsProps> = ({
                   onConsumeTopicShortcut={onConsumeTopicShortcut}
                   onManageAccessShortcut={onManageAccessShortcut}
                   onDelete={onDeleteNewAcl}
-                  resourceNameOptions={resourceNameOptions}
-                  fetchConsumeTopicShortcutResourceName={
-                    fetchConsumeTopicShortcutResourceName
-                  }
-                  onFetchConsumeTopicShortcutTopicResourceNameOptions={
-                    onFetchConsumeTopicShortcutTopicResourceNameOptions
-                  }
-                  onFetchProduceTopicShortcutResourceNameOptions={
-                    onFetchProduceTopicShortcutResourceNameOptions
-                  }
-                  fetchConsumeTopicShortcutTopicResourceNameOptions={
-                    onFetchConsumeTopicShortcutTopicResourceNameOptions
-                  }
+                  topicNameOptions={topicNameOptions}
+                  consumerGroupNameOptions={consumerGroupNameOptions}
                   addedAcls={newAcls}
                   kafkaName={kafkaName}
                   setAddedAcls={setNewAcls}

--- a/src/Kafka/ManageKafkaPermissions/components/AssgnPermissionsManual.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/AssgnPermissionsManual.stories.tsx
@@ -1,19 +1,17 @@
 import { TableComposable } from "@patternfly/react-table";
 import { Form } from "@patternfly/react-core";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
-import { fakeApi } from "../../../shared/storiesHelpers";
 import { AssignPermissionsManual } from "./AssignPermissionsManual";
 
 export default {
   component: AssignPermissionsManual,
   args: {
-    onFetchResourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
+    onFetchResourceNameOptions: (filter: string) => {
+      return ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
+        v.includes(filter)
+      );
+    },
+
     resourceType: undefined,
     submitted: false,
     resourcePrefix: "Is",

--- a/src/Kafka/ManageKafkaPermissions/components/AssignPermissions.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/AssignPermissions.tsx
@@ -10,18 +10,9 @@ import { ShortcutsTableHead } from "./ShortcutsTableHead";
 
 export type AssignPermissionsProps = {
   submitted: boolean;
-  resourceNameOptions: (filter: string) => Promise<string[]>;
   onDelete: (index: number) => void;
-  fetchConsumeTopicShortcutResourceName: (filter: string) => Promise<string[]>;
-  onFetchConsumeTopicShortcutTopicResourceNameOptions: (
-    filter: string
-  ) => Promise<string[]>;
-  onFetchProduceTopicShortcutResourceNameOptions: (
-    filter: string
-  ) => Promise<string[]>;
-  fetchConsumeTopicShortcutTopicResourceNameOptions: (
-    filter: string
-  ) => Promise<string[]>;
+  topicNameOptions: (filter: string) => string[];
+  consumerGroupNameOptions: (filter: string) => string[];
   addedAcls?: AddAclType[];
   onAddManualPermissions: () => void;
   onAddProduceTopicShortcut: () => void;
@@ -33,12 +24,10 @@ export type AssignPermissionsProps = {
 };
 
 export const AssignPermissions: React.VFC<AssignPermissionsProps> = ({
-  resourceNameOptions,
   submitted,
   onDelete,
-  fetchConsumeTopicShortcutResourceName,
-  onFetchConsumeTopicShortcutTopicResourceNameOptions,
-  onFetchProduceTopicShortcutResourceNameOptions,
+  topicNameOptions,
+  consumerGroupNameOptions,
   onAddManualPermissions,
   onAddProduceTopicShortcut,
   onConsumeTopicShortcut,
@@ -91,7 +80,7 @@ export const AssignPermissions: React.VFC<AssignPermissionsProps> = ({
                         })
                       )
                     }
-                    onFetchResourceNameOptions={resourceNameOptions}
+                    onFetchResourceNameOptions={topicNameOptions}
                     resourcePermission={aclTemplate.resourcePermission}
                     onChangeResourcePermission={(value) =>
                       setAddedAcls(
@@ -183,11 +172,9 @@ export const AssignPermissions: React.VFC<AssignPermissionsProps> = ({
                       )
                     }
                     onFetchConsumerResourceNameOptions={
-                      fetchConsumeTopicShortcutResourceName
+                      consumerGroupNameOptions
                     }
-                    onFetchTopicResourceNameOptions={
-                      onFetchConsumeTopicShortcutTopicResourceNameOptions
-                    }
+                    onFetchTopicResourceNameOptions={topicNameOptions}
                     submitted={submitted}
                     onDelete={onDelete}
                     row={idx}
@@ -222,9 +209,7 @@ export const AssignPermissions: React.VFC<AssignPermissionsProps> = ({
                         })
                       )
                     }
-                    onFetchResourceNameOptions={
-                      onFetchProduceTopicShortcutResourceNameOptions
-                    }
+                    onFetchResourceNameOptions={topicNameOptions}
                     submitted={submitted}
                     onDelete={onDelete}
                     row={idx}

--- a/src/Kafka/ManageKafkaPermissions/components/AssignPermissionsManual.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/AssignPermissionsManual.tsx
@@ -21,7 +21,7 @@ export type AssignPermissionsManualProps = {
   onChangeResourcePrefix: (value: ResourcePrefixRuleValue) => void;
   resourceName: string | undefined;
   onChangeResource: (value: string | undefined) => void;
-  onFetchResourceNameOptions: (filter: string) => Promise<string[]>;
+  onFetchResourceNameOptions: (filter: string) => string[];
   resourcePermission: ResourcePermissionValue;
   onChangeResourcePermission: (value: ResourcePermissionValue) => void;
   resourceOperation: ResourceOperationValue | undefined;

--- a/src/Kafka/ManageKafkaPermissions/components/ConsumeTopicShortcut.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ConsumeTopicShortcut.stories.tsx
@@ -1,26 +1,24 @@
 import { TableComposable } from "@patternfly/react-table";
 import { Form } from "@patternfly/react-core";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
-import { fakeApi } from "../../../shared/storiesHelpers";
 import { ConsumeTopicShortcut } from "./ConsumeTopicShortcut";
 
 export default {
   component: ConsumeTopicShortcut,
   args: {
-    onFetchConsumerResourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo-consumer", "test", "my-consumer", "random-consumer-name"].filter(
-          (v) => v.includes(filter)
-        ),
-        100
-      ),
-    onFetchTopicResourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
+    onFetchConsumerResourceNameOptions: (filter: string) => {
+      return [
+        "foo-consumer",
+        "test",
+        "my-consumer",
+        "random-consumer-name",
+      ].filter((v) => v.includes(filter));
+    },
+    onFetchTopicResourceNameOptions: (filter: string) => {
+      return ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
+        v.includes(filter)
+      );
+    },
     topicPrefixRuleValue: "Starts with",
     consumerPrefixRuleValue: "Starts with",
     submitted: false,

--- a/src/Kafka/ManageKafkaPermissions/components/ConsumeTopicShortcut.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ConsumeTopicShortcut.tsx
@@ -21,8 +21,8 @@ export type ConsumeTopicShortcutProps = {
   topicResourceNameValue: string | undefined;
   onChangeConsumerResourceName: (value: string | undefined) => void;
   onChangeTopicResourceName: (value: string | undefined) => void;
-  onFetchConsumerResourceNameOptions: (filter: string) => Promise<string[]>;
-  onFetchTopicResourceNameOptions: (filter: string) => Promise<string[]>;
+  onFetchConsumerResourceNameOptions: (filter: string) => string[];
+  onFetchTopicResourceNameOptions: (filter: string) => string[];
   submitted: boolean;
   multipleShorctutPermissions?: boolean;
   onDelete: (row: number) => void;

--- a/src/Kafka/ManageKafkaPermissions/components/ProduceTopicRow.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ProduceTopicRow.tsx
@@ -10,7 +10,7 @@ export type ProduceTopicRowProps = {
   prefixRuleValue: ResourcePrefixRuleValue;
   resourceNameValue: string | undefined;
   onChangeResourceName: (value: string | undefined) => void;
-  onFetchResourceNameOptions: (filter: string) => Promise<string[]>;
+  onFetchResourceNameOptions: (filter: string) => string[];
   submitted: boolean;
   isConsumeTopicShortcut?: boolean;
   setIsNameValid: (value: boolean) => void;

--- a/src/Kafka/ManageKafkaPermissions/components/ProduceTopicShortcut.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ProduceTopicShortcut.stories.tsx
@@ -1,5 +1,4 @@
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
-import { fakeApi } from "../../../shared/storiesHelpers";
 import { ProduceTopicShortcut } from "./ProduceTopicShortcut";
 import { TableComposable } from "@patternfly/react-table";
 
@@ -8,17 +7,11 @@ export default {
   args: {
     prefixRuleValue: "Starts with",
     submitted: false,
-    onFetchResourceNameOptions: (filter) =>
-      fakeApi<string[]>(
-        [
-          "foo-topic",
-          "test",
-          "my-test",
-          "random-topic-name",
-          "...topic",
-        ].filter((v) => v.includes(filter)),
-        100
-      ),
+    onFetchResourceNameOptions: (filter: string) => {
+      return ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
+        v.includes(filter)
+      );
+    },
   },
 } as ComponentMeta<typeof ProduceTopicShortcut>;
 

--- a/src/Kafka/ManageKafkaPermissions/components/ProduceTopicShortcut.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ProduceTopicShortcut.tsx
@@ -13,7 +13,7 @@ export type ProduceTopicShortcutProps = {
   prefixRuleValue: ResourcePrefixRuleValue;
   resourceNameValue: string | undefined;
   onChangeResourceName: (value: string | undefined) => void;
-  onFetchResourceNameOptions: (filter: string) => Promise<string[]>;
+  onFetchResourceNameOptions: (filter: string) => string[];
   submitted: boolean;
   onDelete: (row: number) => void;
   multipleShorctutPermissions?: boolean;

--- a/src/Kafka/ManageKafkaPermissions/components/ResourceName.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ResourceName.stories.tsx
@@ -2,20 +2,17 @@ import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { ResourceName } from "./ResourceName";
 import { Form } from "@patternfly/react-core";
 import { userEvent, within } from "@storybook/testing-library";
-import { fakeApi } from "../../../shared/storiesHelpers";
 
 export default {
   component: ResourceName,
   args: {
     value: undefined,
     setIsNameValid: (value) => value,
-    onFetchOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
+    onFetchOptions: (filter: string) => {
+      return ["foo-topic", "test", "my-test", "random-topic-name"].filter((v) =>
+        v.includes(filter)
+      );
+    },
     submitted: false,
     resourcePrefixRule: "Is",
     resourceType: "topic",

--- a/src/Kafka/ManageKafkaPermissions/components/ResourceName.test.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ResourceName.test.tsx
@@ -29,10 +29,13 @@ describe("Resource Name", () => {
       "A topic name must contain at least 3 periods (...) if periods are the only characters used."
     );
     expect(option).toBeInTheDocument();
-    expect(onChangeValue).not.toHaveBeenCalled();
+    expect(onChangeValue).toHaveBeenCalledTimes(2);
   });
   it("should render a select with validation message for invalid consumer group characters", async () => {
-    const comp = render(<InvalidConsumerGroupCharacters />);
+    const onChange = jest.fn();
+    const comp = render(
+      <InvalidConsumerGroupCharacters onChangeValue={onChange} />
+    );
     await waitForI18n(comp);
     await waitForPopper();
     const placeHolderText = await comp.findByPlaceholderText("Enter name");
@@ -51,7 +54,8 @@ describe("Resource Name", () => {
     expect(option).toBeInTheDocument();
   });
   it("should render a select with validation message for invalid length of input value", async () => {
-    const comp = render(<InvalidLength />);
+    const onChange = jest.fn();
+    const comp = render(<InvalidLength onChangeValue={onChange} />);
     await waitForI18n(comp);
     await waitForPopper();
     const placeHolderText = await comp.findByPlaceholderText("Enter name");
@@ -73,13 +77,15 @@ describe("Resource Name", () => {
     expect(option).toBeInTheDocument();
   });
   it("should render a select with validation message 'Required' for a mandatory field submitted undefined", async () => {
-    const comp = render(<RequiredField />);
+    const onChange = jest.fn();
+    const comp = render(<RequiredField onChangeValue={onChange} />);
     await waitForI18n(comp);
     const option = await comp.findByText("Required");
     expect(option).toBeInTheDocument();
   });
   it("should render a select with validation message for invalid topic characters used", async () => {
-    const comp = render(<InvalidTopicCharacters />);
+    const onChange = jest.fn();
+    const comp = render(<InvalidTopicCharacters onChangeValue={onChange} />);
     await waitForI18n(comp);
     await waitForPopper();
     const placeHolderText = await comp.findByPlaceholderText("Enter name");

--- a/src/Kafka/ManageKafkaPermissions/components/ResourceName.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ResourceName.tsx
@@ -6,7 +6,7 @@ import { AsyncTypeaheadSelect } from "../../../shared";
 type ResourceNameProps = {
   value: string | undefined;
   onChangeValue: (value: string | undefined) => void;
-  onFetchOptions: (filter: string) => Promise<string[]>;
+  onFetchOptions: (filter: string) => string[];
   submitted: boolean;
   resourceType: ResourceTypeValue | undefined;
   resourcePrefixRule: ResourcePrefixRuleValue;

--- a/src/shared/AsyncTypeaheadSelect/AsyncTypeaheadSelect.stories.tsx
+++ b/src/shared/AsyncTypeaheadSelect/AsyncTypeaheadSelect.stories.tsx
@@ -2,21 +2,18 @@ import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { AsyncTypeaheadSelect } from "./AsyncTypeaheadSelect";
 import { Form } from "@patternfly/react-core";
 import { userEvent, within } from "@storybook/testing-library";
-import { fakeApi } from "../storiesHelpers";
 
 export default {
   component: AsyncTypeaheadSelect,
   args: {
     id: "sample",
+    onFetchOptions: (filter: string) => {
+      return ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
+        v.includes(filter)
+      );
+    },
     value: undefined,
     ariaLabel: "my aria label",
-    onFetchOptions: (filter) =>
-      fakeApi<string[]>(
-        ["foo", "bar", "baz", `random ${Math.random()}`].filter((v) =>
-          v.includes(filter)
-        ),
-        100
-      ),
     onValidationCheck: () => ({ isValid: true, message: undefined }),
     placeholderText: "Enter name",
   },
@@ -54,23 +51,6 @@ PlaceHolderVariation.parameters = {
   docs: {
     description: {
       story: `A variation of the async typeahead with a different placholder`,
-    },
-  },
-};
-
-export const LoadingSuggestions = Template.bind({});
-LoadingSuggestions.args = {
-  onFetchOptions: () => new Promise(() => false),
-};
-
-LoadingSuggestions.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  await userEvent.click(await canvas.findByPlaceholderText("Enter name"));
-};
-LoadingSuggestions.parameters = {
-  docs: {
-    description: {
-      story: `A user clicks on the async typeahead. Until the list of suggestions is ready to be dispayed, a spinner shows `,
     },
   },
 };

--- a/src/shared/AsyncTypeaheadSelect/AsyncTypeaheadSelect.test.tsx
+++ b/src/shared/AsyncTypeaheadSelect/AsyncTypeaheadSelect.test.tsx
@@ -7,7 +7,6 @@ const {
   InitialState,
   ValidInput,
   PlaceHolderVariation,
-  LoadingSuggestions,
   CreatableText,
   RequiredField,
 } = composeStories(stories);
@@ -30,7 +29,7 @@ describe("Async typeahead", () => {
     expect(comp.queryByText("bar")).not.toBeInTheDocument();
 
     expect(onChangeValue).not.toBeCalled();
-    expect(onFetchOptions).not.toBeCalled();
+    expect(onFetchOptions).toBeCalledTimes(1);
     expect(onValidationCheck).not.toBeCalled();
   });
   it("It should render an async typeahead with a valid value selected", async () => {
@@ -41,7 +40,8 @@ describe("Async typeahead", () => {
   });
 
   it("should show a custom placeholder", async () => {
-    const comp = render(<PlaceHolderVariation />);
+    const onChange = jest.fn();
+    const comp = render(<PlaceHolderVariation onChange={onChange} />);
     await waitForI18n(comp);
 
     expect(comp.getByPlaceholderText("Enter prefix")).toBeInTheDocument();
@@ -55,28 +55,6 @@ describe("Async typeahead", () => {
     expect(option).not.toBeInTheDocument();
   });
 
-  it("should show a loading spinner when typeahead suggestions are loading ", async () => {
-    const onFetchOptions = jest.fn(LoadingSuggestions.args!.onFetchOptions);
-    const onValidationCheck = jest.fn();
-
-    const comp = render(
-      <LoadingSuggestions
-        onFetchOptions={onFetchOptions}
-        onValidationCheck={onValidationCheck}
-      />
-    );
-    await waitForI18n(comp);
-    const select = comp.getByPlaceholderText("Enter name");
-    userEvent.click(select);
-
-    await waitForPopper();
-
-    expect(comp.getByRole("progressbar")).toBeInTheDocument();
-    jest.advanceTimersByTime(1000);
-    expect(onFetchOptions).toBeCalledTimes(1);
-    expect(onValidationCheck).not.toBeCalled();
-  });
-
   it("should show an option to 'Use {{input value}}' if a valid value is typed ", async () => {
     const onChange = jest.fn();
     await act(async () => {
@@ -87,10 +65,10 @@ describe("Async typeahead", () => {
       const option = await comp.findByText('Use "test-topic-name"');
       expect(option).toBeInTheDocument();
 
-      expect(onChange).not.toBeCalled();
+      expect(onChange).not.toBeCalledTimes(1);
 
       userEvent.click(option);
-      expect(onChange).toBeCalledTimes(1);
+      expect(onChange).toBeCalledTimes(3);
     });
   });
 });
@@ -107,10 +85,10 @@ it("should show a validation error ", async () => {
     userEvent.type(select, "foo");
     await waitForPopper();
     const clearBtn = comp.getAllByRole("button");
-    expect(onChange).not.toBeCalled();
+    expect(onChange).not.toBeCalledTimes(2);
     userEvent.click(clearBtn[0]);
     await waitForPopper();
-    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
Signed-off-by: suyash-naithani <suyash.naithani@gmail.com>

While integrating the acls, we realised that an async call for the topics and consumer groups is not needed. This PR removes the async props from the acl to simply return an array of string 