### PR TITLE
chore: fix kafka instance name alignment

### DIFF
--- a/src/Kafka/KafkaInstances/components/InstancesTable.tsx
+++ b/src/Kafka/KafkaInstances/components/InstancesTable.tsx
@@ -128,6 +128,7 @@ export const InstancesTable = <T extends KafkaInstance>({
                           {row.name}
                         </Link>
                       )}
+                      isInline
                       isDisabled={DeletingStatuses.includes(row["status"])}
                       onClick={() => onInstanceLinkClick(row)}
                     />


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:
 Jenn noticed an alignment issue in the Kafka topic name column https://github.com/redhat-developer/app-services-ui-components/pull/546#issuecomment-1313843471 same issue I noticed in the Instance Table name column 
 
The PR fix the alignment issue in the Kafka instance name




