### PR TITLE
chore: Remove coming soon text from GCP on overview page

### DIFF
--- a/locales/en/kafkaoverview-v3.json
+++ b/locales/en/kafkaoverview-v3.json
@@ -7,7 +7,6 @@
   "dataTransfer": "Data transfer",
   "dataTransfer_price": "$0.09 / GB",
   "firstStreamingUnit": "1 streaming unit",
-  "googleCloudProviderDescription": "Coming Soon",
   "googleCloudProviderTitle": "Google Cloud Platform",
   "heroDescription": "Red Hat OpenShift Streams for Apache $t(common:kafka) is a managed cloud service that provides a streamlined developer experience for building, deploying, and scaling real-time applications in hybrid-cloud environments. The combination of seamless operations across distributed microservices, large data transfer volumes, and managed operations allows teams to focus on core competencies, accelerate application velocity and reduce operational cost.",
   "heroTagline": "Fully hosted and managed service for stream-based applications",

--- a/src/AppServices/KafkaPageV3.test.tsx
+++ b/src/AppServices/KafkaPageV3.test.tsx
@@ -1,0 +1,13 @@
+import { composeStories } from "@storybook/testing-react";
+import { render, waitForI18n } from "../test-utils";
+import * as stories from "./KafkaPageV3.stories";
+
+const { KafkaPageV3 } = composeStories(stories);
+
+describe("KafkaPage", () => {
+  it("renders", async () => {
+    const comp = render(<KafkaPageV3 />);
+    await waitForI18n(comp);
+    expect(comp.baseElement).toMatchSnapshot();
+  });
+});

--- a/src/AppServices/KafkaPageV3.tsx
+++ b/src/AppServices/KafkaPageV3.tsx
@@ -286,12 +286,6 @@ export const KafkaPageV3: FunctionComponent = () => {
                       <Title headingLevel="h2" className={"pf-u-pt-sm"}>
                         {t("googleCloudProviderTitle")}
                       </Title>
-                      <Text
-                        component={TextVariants.p}
-                        className={"pf-u-color-200"}
-                      >
-                        {t("googleCloudProviderDescription")}
-                      </Text>
                     </SplitItem>
                   </Split>
                 </FlexItem>

--- a/src/AppServices/__snapshots__/KafkaPageV3.test.tsx.snap
+++ b/src/AppServices/__snapshots__/KafkaPageV3.test.tsx.snap
@@ -1,0 +1,890 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KafkaPage renders 1`] = `
+<body>
+  <div>
+    <section
+      class="pf-c-page__main-section pf-m-light appsrv-marketing--banner pf-u-background-color-100"
+      style="--appsrv-marketing--banner--before--BackgroundImage: url(dummyimage); --appsrv-marketing--banner--before--BackgroundSize: 478px; --appsrv-marketing--banner--before--BackgroundRepeat: no-repeat; --appsrv-marketing--banner--before--BackgroundPositionY: -99px;"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <h1
+          class="pf-c-title pf-m-2xl"
+          data-ouia-component-id="OUIA-Generated-Title-1"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe="true"
+        >
+          Get started with Red Hat OpenShift Streams for Apache Kafka
+        </h1>
+        <p
+          class="appsrv-marketing--banner__tagline pf-u-color-200"
+          data-ouia-component-id="OUIA-Generated-Text-1"
+          data-ouia-component-type="PF4/Text"
+          data-ouia-safe="true"
+          data-pf-content="true"
+        >
+          Fully hosted and managed service for stream-based applications
+        </p>
+        <p
+          class=""
+          data-ouia-component-id="OUIA-Generated-Text-2"
+          data-ouia-component-type="PF4/Text"
+          data-ouia-safe="true"
+          data-pf-content="true"
+        >
+          Red Hat OpenShift Streams for Apache Kafka is a managed cloud service that provides a streamlined developer experience for building, deploying, and scaling real-time applications in hybrid-cloud environments. The combination of seamless operations across distributed microservices, large data transfer volumes, and managed operations allows teams to focus on core competencies, accelerate application velocity and reduce operational cost.
+        </p>
+      </div>
+    </section>
+    <section
+      class="pf-c-page__main-section pf-m-limit-width appsrv-marketing--page-section--marketing"
+    >
+      <div
+        class="pf-c-page__main-body"
+      >
+        <div
+          class="pf-l-grid pf-m-all-6-col-on-lg pf-m-gutter"
+        >
+          <article
+            aria-label="Purchase now"
+            class="pf-c-card"
+            data-ouia-component-id="card-overview-purchase-now"
+            data-ouia-component-type="PF4/Card"
+            data-ouia-safe="true"
+            id=""
+          >
+            <div
+              class="pf-c-card__header"
+            >
+              <div
+                class=""
+              >
+                <div
+                  class="pf-c-card__title"
+                >
+                  <h2
+                    class="pf-c-title pf-m-xl"
+                    data-ouia-component-id="OUIA-Generated-Title-2"
+                    data-ouia-component-type="PF4/Title"
+                    data-ouia-safe="true"
+                  >
+                    Purchase now 
+                    <span
+                      class="pf-u-color-200 pf-u-font-size-sm"
+                    >
+                      (US and Canada only)
+                    </span>
+                  </h2>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-c-card__body"
+            >
+              Purchase a pay-as-you-go subscription for up to 25 streaming units using one of our Marketplace options below.
+            </div>
+            <div
+              class="pf-c-card__footer"
+            >
+              <div
+                class="pf-l-flex pf-m-space-items-2xl"
+              >
+                <div
+                  class=""
+                >
+                  <a
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link pf-m-inline"
+                    data-ouia-component-id="OUIA-Generated-Button-link-1"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    data-testid="cardPurchase-buttonRH"
+                    href="https://marketplace.redhat.com/en-us/products/red-hat-openshift-streams-for-apache-kafka"
+                    target="_blank"
+                  >
+                    <span
+                      class="pf-u-font-size-lg"
+                    >
+                      <strong>
+                        Red Hat Marketplace
+                      </strong>
+                      <span
+                        class="pf-u-font-size-lg"
+                      />
+                    </span>
+                    <span
+                      style="white-space: nowrap;"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="pf-u-ml-md "
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                        />
+                      </svg>
+                    </span>
+                  </a>
+                </div>
+                <div
+                  class=""
+                >
+                  <a
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link pf-m-inline"
+                    data-ouia-component-id="OUIA-Generated-Button-link-2"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    data-testid="cardPurchase-buttonAWS"
+                    href="https://aws.amazon.com/marketplace/pp/prodview-3xohcoyuwkumc"
+                    target="_blank"
+                  >
+                    <span
+                      class="pf-u-font-size-lg"
+                    >
+                      <strong>
+                        AWS Marketplace
+                      </strong>
+                      <span
+                        class="pf-u-font-size-lg"
+                      />
+                    </span>
+                    <span
+                      style="white-space: nowrap;"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="pf-u-ml-md"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                        />
+                      </svg>
+                    </span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <article
+            aria-label="Contact sales"
+            class="pf-c-card"
+            data-ouia-component-id="card-overview-contact-sales"
+            data-ouia-component-type="PF4/Card"
+            data-ouia-safe="true"
+            id=""
+          >
+            <div
+              class="pf-c-card__header"
+            >
+              <div
+                class="pf-c-card__title"
+              >
+                <h2
+                  class="pf-c-title pf-m-xl"
+                  data-ouia-component-id="OUIA-Generated-Title-3"
+                  data-ouia-component-type="PF4/Title"
+                  data-ouia-safe="true"
+                >
+                  Contact sales 
+                  <span
+                    class="pf-u-color-200 pf-u-font-size-sm"
+                  >
+                    (Available for all regions)
+                  </span>
+                </h2>
+              </div>
+            </div>
+            <div
+              class="pf-c-card__body"
+            >
+              Contact sales to get a prepaid subscription that fits your needs. Sales can help set up a prepaid subscription, modify a current subscription or get a longer trial.
+            </div>
+            <div
+              class="pf-c-card__footer"
+            >
+              <a
+                aria-disabled="false"
+                class="pf-c-button pf-m-link pf-m-inline"
+                data-ouia-component-id="OUIA-Generated-Button-link-3"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                data-testid="cardContactSales-buttonCTA"
+                href="https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-streams-for-apache-kafka#contact-us"
+                target="_blank"
+              >
+                <span
+                  class="pf-u-font-size-lg"
+                >
+                  <strong>
+                    Contact sales
+                  </strong>
+                </span>
+                <span
+                  style="white-space: nowrap;"
+                >
+                   
+                  <svg
+                    aria-hidden="true"
+                    class="pf-u-ml-md"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+    <section
+      class="pf-c-page__main-section pf-m-limit-width kafka-overview--page-section--marketing"
+    >
+      <div
+        class="pf-c-page__main-body"
+      >
+        <article
+          class="pf-c-card"
+          data-ouia-component-id="OUIA-Generated-Card-1"
+          data-ouia-component-type="PF4/Card"
+          data-ouia-safe="true"
+          id=""
+        >
+          <div
+            class="pf-c-card__title"
+          >
+            <h2
+              class="pf-c-title pf-m-xl"
+              data-ouia-component-id="OUIA-Generated-Title-4"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe="true"
+            >
+              Pricing model
+            </h2>
+          </div>
+          <div
+            class="pf-c-card__body"
+          >
+            <div
+              class="pf-l-flex pf-m-space-items-xl"
+            >
+              <div
+                class="pf-l-flex pf-m-flex-1 pf-m-align-self-center pf-m-justify-content-center"
+              >
+                <div
+                  class=""
+                >
+                  <dl
+                    class="pf-c-description-list pf-m-horizontal"
+                  >
+                    <div
+                      class="pf-c-description-list__group"
+                    >
+                      <dt
+                        class="pf-c-description-list__term"
+                      >
+                        <span
+                          class="pf-c-description-list__text"
+                        >
+                          Streaming unit
+                        </span>
+                      </dt>
+                      <dd
+                        class="pf-c-description-list__description"
+                      >
+                        <div
+                          class="pf-c-description-list__text"
+                        >
+                          $1.49 / hour
+                        </div>
+                      </dd>
+                    </div>
+                    <div
+                      class="pf-c-description-list__group"
+                    >
+                      <dt
+                        class="pf-c-description-list__term"
+                      >
+                        <span
+                          class="pf-c-description-list__text"
+                        >
+                          Data transfer
+                        </span>
+                      </dt>
+                      <dd
+                        class="pf-c-description-list__description"
+                      >
+                        <div
+                          class="pf-c-description-list__text"
+                        >
+                          $0.09 / GB
+                        </div>
+                      </dd>
+                    </div>
+                    <div
+                      class="pf-c-description-list__group"
+                    >
+                      <dt
+                        class="pf-c-description-list__term"
+                      >
+                        <span
+                          class="pf-c-description-list__text"
+                        >
+                          Storage
+                        </span>
+                      </dt>
+                      <dd
+                        class="pf-c-description-list__description"
+                      >
+                        <div
+                          class="pf-c-description-list__text"
+                        >
+                          $0.10 / GB month
+                        </div>
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </div>
+              <hr
+                class="pf-c-divider pf-m-vertical"
+              />
+              <div
+                class="pf-m-flex-1"
+              >
+                <div
+                  class="pf-c-content"
+                >
+                  <p
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-Text-3"
+                    data-ouia-component-type="PF4/Text"
+                    data-ouia-safe="true"
+                    data-pf-content="true"
+                  >
+                    A 
+                    <strong>
+                      streaming unit
+                    </strong>
+                     determines the default maximum capacity of a Kafka instance. The more streaming units your Kafka instance has, the larger its capacity will be.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+    <section
+      class="pf-c-page__main-section pf-m-limit-width kafka-overview--page-section--marketing"
+    >
+      <div
+        class="pf-c-page__main-body"
+      >
+        <article
+          class="pf-c-card"
+          data-ouia-component-id="OUIA-Generated-Card-2"
+          data-ouia-component-type="PF4/Card"
+          data-ouia-safe="true"
+          id=""
+        >
+          <div
+            class="pf-c-card__title"
+          >
+            <h2
+              class="pf-c-title pf-m-xl"
+              data-ouia-component-id="OUIA-Generated-Title-5"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe="true"
+            >
+              Kafka instance capacity
+            </h2>
+          </div>
+          <div
+            class="pf-c-card__body"
+          >
+            <div
+              class="pf-l-stack pf-m-gutter"
+            >
+              <p
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-4"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                Streams for Apache Kafka offers instances in the following sizes with the following capacity.
+              </p>
+              <table
+                class="pf-c-table pf-m-grid-md"
+                data-ouia-component-id="OUIA-Generated-Table-1"
+                data-ouia-component-type="PF4/Table"
+                data-ouia-safe="true"
+                role="grid"
+              >
+                <thead
+                  class=""
+                >
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-1"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <th
+                      class=""
+                    />
+                    <th
+                      class=""
+                      scope="col"
+                    >
+                      1 streaming unit
+                    </th>
+                    <th
+                      class=""
+                      scope="col"
+                    >
+                      2 streaming units
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class=""
+                  role="rowgroup"
+                >
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-2"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Ingress (MB/second)
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 50
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 100
+                    </td>
+                  </tr>
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-3"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Egress (MB/second)
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 100
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 200
+                    </td>
+                  </tr>
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-4"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Storage* (GB)
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 1000
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 2000
+                    </td>
+                  </tr>
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-5"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Topic partitions
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 1500
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 3000
+                    </td>
+                  </tr>
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-6"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Client connections
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 3000
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 6000
+                    </td>
+                  </tr>
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-7"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Connection rate (connections/second)
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 100
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 200
+                    </td>
+                  </tr>
+                  <tr
+                    class=""
+                    data-ouia-component-id="OUIA-Generated-TableRow-8"
+                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class=""
+                      data-label=""
+                    >
+                      Message size (MB)
+                    </td>
+                    <td
+                      class=""
+                      data-label="1 streaming unit"
+                    >
+                      up to 1
+                    </td>
+                    <td
+                      class=""
+                      data-label="2 streaming units"
+                    >
+                      up to 1
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div
+            class="pf-c-card__footer"
+          >
+            <div
+              class="pf-c-content pf-u-font-size-sm"
+            >
+              *Storage can be extended. If you wish to increase the storage limit for a Kafka instance, contact 
+              <a
+                aria-disabled="false"
+                class="pf-c-button pf-m-link pf-m-inline"
+                data-ouia-component-id="OUIA-Generated-Button-link-4"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                data-testid="SupportLink"
+                href="https://access.redhat.com/support"
+                target="_blank"
+              >
+                Red Hat support
+                <span
+                  style="white-space: nowrap;"
+                >
+                   
+                  <svg
+                    aria-hidden="true"
+                    class="pf-u-ml-xs"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                    />
+                  </svg>
+                </span>
+              </a>
+               to discuss your options. You can check your current storage usage by 
+              <a
+                aria-disabled="false"
+                class="pf-c-button pf-m-link pf-m-inline"
+                data-ouia-component-id="OUIA-Generated-Button-link-5"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                data-testid="MonitoringDiskSpaceLink"
+                href="https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/aced8e5e-8229-4cb2-82f9-87a8caa24bb3"
+                target="_blank"
+              >
+                monitoring disk space metrics
+                <span
+                  style="white-space: nowrap;"
+                >
+                   
+                  <svg
+                    aria-hidden="true"
+                    class="pf-u-ml-xs"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                    />
+                  </svg>
+                </span>
+              </a>
+              .
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+    <section
+      class="pf-c-page__main-section pf-m-limit-width kafka-overview--page-section--marketing"
+    >
+      <div
+        class="pf-c-page__main-body"
+      >
+        <article
+          class="pf-c-card"
+          data-ouia-component-id="OUIA-Generated-Card-3"
+          data-ouia-component-type="PF4/Card"
+          data-ouia-safe="true"
+          id=""
+        >
+          <div
+            class="pf-c-card__title"
+          >
+            <h2
+              class="pf-c-title pf-m-xl"
+              data-ouia-component-id="OUIA-Generated-Title-6"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe="true"
+            >
+              Cloud providers
+            </h2>
+          </div>
+          <div
+            class="pf-c-card__body"
+          >
+            <div
+              class="pf-l-flex pf-m-space-items-xl pf-m-column pf-m-row-on-xl"
+            >
+              <div
+                class="pf-l-flex pf-m-flex-1 pf-m-justify-content-center"
+              >
+                <div
+                  class=""
+                >
+                  <div
+                    class="pf-l-split pf-m-gutter"
+                  >
+                    <div
+                      class="pf-l-split__item"
+                    >
+                      <img
+                        alt=""
+                        style="height: 60px;"
+                      />
+                    </div>
+                    <div
+                      class="pf-l-split__item"
+                    >
+                      <h2
+                        class="pf-c-title pf-m-xl pf-u-pt-sm"
+                        data-ouia-component-id="OUIA-Generated-Title-7"
+                        data-ouia-component-type="PF4/Title"
+                        data-ouia-safe="true"
+                      >
+                        Amazon Web Services
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="pf-c-divider pf-m-vertical-on-xl"
+              />
+              <div
+                class="pf-l-flex pf-m-flex-1 pf-m-justify-content-center"
+              >
+                <div
+                  class=""
+                >
+                  <div
+                    class="pf-l-split pf-m-gutter"
+                  >
+                    <div
+                      class="pf-l-split__item"
+                    >
+                      <img
+                        alt=""
+                        style="height: 60px;"
+                      />
+                    </div>
+                    <div
+                      class="pf-l-split__item"
+                    >
+                      <h2
+                        class="pf-c-title pf-m-xl pf-u-pt-sm"
+                        data-ouia-component-id="OUIA-Generated-Title-8"
+                        data-ouia-component-type="PF4/Title"
+                        data-ouia-safe="true"
+                      >
+                        Google Cloud Platform
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="pf-c-divider pf-m-vertical-on-xl"
+              />
+              <div
+                class="pf-l-flex pf-m-flex-1 pf-m-justify-content-center"
+              >
+                <div
+                  class=""
+                >
+                  <div
+                    class="pf-l-split pf-m-gutter"
+                  >
+                    <div
+                      class="pf-l-split__item"
+                    >
+                      <img
+                        alt=""
+                        style="height: 60px;"
+                      />
+                    </div>
+                    <div
+                      class="pf-l-split__item"
+                    >
+                      <h2
+                        class="pf-c-title pf-m-xl pf-u-pt-sm"
+                        data-ouia-component-id="OUIA-Generated-Title-9"
+                        data-ouia-component-type="PF4/Title"
+                        data-ouia-safe="true"
+                      >
+                        Microsoft Azure
+                      </h2>
+                      <p
+                        class="pf-u-color-200"
+                        data-ouia-component-id="OUIA-Generated-Text-5"
+                        data-ouia-component-type="PF4/Text"
+                        data-ouia-safe="true"
+                        data-pf-content="true"
+                      >
+                        Coming soon
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  </div>
+  <div>
+    <ul
+      aria-atomic="false"
+      aria-live="polite"
+      class="pf-c-alert-group pf-m-toast"
+    />
+  </div>
+</body>
+`;

--- a/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.stories.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.stories.tsx
@@ -30,6 +30,7 @@ export default {
     messageSize: 1,
     billing: "prepaid",
     kafkaVersion: "3.0.1",
+    cloudProvider: "gcp",
   },
   argTypes: {
     billing: {

--- a/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.tsx
+++ b/src/Kafka/KafkaInstanceDrawer/KafkaDetailsTab.tsx
@@ -9,7 +9,7 @@ import {
 import type { ReactChild, VoidFunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { FormatDate } from "../../shared";
-import type { MarketplaceSubscription } from "../types";
+import type { CloudProvider, MarketplaceSubscription } from "../types";
 import type { InstanceType } from "../utils";
 import { DetailsTabAlert } from "./components/DetailsTabAlert";
 
@@ -35,6 +35,7 @@ export type KafkaDetailsTabProps = {
   messageSize: number | undefined;
   billing: "prepaid" | MarketplaceSubscription | undefined;
   kafkaVersion: string;
+  cloudProvider: CloudProvider;
 };
 
 export const KafkaDetailsTab: VoidFunctionComponent<KafkaDetailsTabProps> = ({
@@ -55,6 +56,7 @@ export const KafkaDetailsTab: VoidFunctionComponent<KafkaDetailsTabProps> = ({
   messageSize,
   billing,
   kafkaVersion,
+  cloudProvider,
 }) => {
   const { t } = useTranslation("kafka");
 
@@ -159,7 +161,16 @@ export const KafkaDetailsTab: VoidFunctionComponent<KafkaDetailsTabProps> = ({
           )}
           {renderTextListItem(
             t("common:cloud_provider"),
-            t("common:cloudProviders.aws")
+            (() => {
+              switch (cloudProvider) {
+                case "aws":
+                  return t("common:cloudProviders.aws");
+                case "gcp":
+                  return t("common:cloudProviders.gcp");
+                case "azure":
+                  return t("common:cloudProviders.azure");
+              }
+            })()
           )}
           {renderTextListItem(t("common:region"), region)}
           {renderTextListItem(

--- a/src/Kafka/KafkaInstanceDrawer/__snapshots__/KafkaDetailsTab.test.tsx.snap
+++ b/src/Kafka/KafkaInstanceDrawer/__snapshots__/KafkaDetailsTab.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`Details Tab renders standard instance 1`] = `
             class=""
             data-pf-content="true"
           >
-            Amazon Web Services
+            Google Cloud Platform
           </dd>
           <dt
             class=""


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

> Remove coming soon text from GCP on the overview page

**Which issue(s) this PR fixes** 

> https://issues.redhat.com/browse/MGDSTRM-9399

**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`

**Is there any work left / what's next** :

> Replace this comment with pending items that need to be covered in this PR or some pending items you are planning to do in the future PR.

**Special notes for your reviewer**:
