### PR TITLE
chore: Set max height for select account

### DIFF
--- a/src/Kafka/ManageKafkaPermissions/components/SelectAccount.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/SelectAccount.tsx
@@ -173,6 +173,7 @@ export const SelectAccount: React.VFC<SelectAccountProps> = ({
         className="kafka-ui--select--limit-height"
         variant={SelectVariant.typeahead}
         typeAheadAriaLabel={t("account_id_title")}
+        maxHeight={400}
         onToggle={onToggle}
         onSelect={onSelect}
         onClear={clearSelection}


### PR DESCRIPTION
The dropdown of select account when open covers the entire page, make the dropdown height smaller and more in line with the current height of the select on our app 