### PR TITLE
chore: Add a play function to correctly show invalid topic name story

### DIFF
--- a/src/Kafka/ManageKafkaPermissions/components/ResourceName.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ResourceName.stories.tsx
@@ -30,6 +30,11 @@ const Template: ComponentStory<typeof ResourceName> = (args) => (
 export const InvalidTopicName = Template.bind({});
 InvalidTopicName.args = { resourceType: "topic" };
 
+InvalidTopicName.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(await canvas.findByPlaceholderText("Enter name"), "..");
+};
+
 InvalidTopicName.parameters = {
   docs: {
     description: {


### PR DESCRIPTION
Added a play function that was missing in the resource name , invalid topic name story 