### PR TITLE
chore: upgrade node version for all gh actions to the latest LTS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-build.yml
     with:
-      node-version: 16.6.2
+      node-version: 18.13.0
 
   release:
     name: Semantic Release
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/actions/cache-restore
         id: cache-node-modules
         with:
-          node-version: 16.6.2
+          node-version: 18.13.0
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
       - uses: ./.github/actions/cache-restore
         id: cache-node-modules
         with:
-          node-version: 16.6.2
+          node-version: 18.13.0
 
       - name: Build storybook
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,5 +8,5 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-build.yml
     with:
-      node-version: 16.6.2
+      node-version: 18.13.0
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.13.0
           registry-url: 'https://registry.npmjs.org'
       - name: Get the version
         id: get_version

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: ./.github/actions/cache-restore
         id: cache-node-modules
         with:
-          node-version: 16.6.2
+          node-version: 18.13.0
 
         #👇 Adds Chromatic as a step in the workflow
       - uses: chromaui/action@v1


### PR DESCRIPTION
**What this PR does / why we need it**:

Hopefully fixes the failing GH actions