### PR TITLE
feat: MGDCTRS-1887 remove service preview label

### DIFF
--- a/src/AppServices/OverviewPageV2.tsx
+++ b/src/AppServices/OverviewPageV2.tsx
@@ -247,7 +247,6 @@ export const OverviewPageV2: FunctionComponent<OverviewPageV2Props> = ({
                     <Label color="blue">
                       {t("overview-v2:applicationService")}
                     </Label>
-                    <Label>{t("overview-v2:servicePreview")}</Label>
                   </LabelGroup>
                 </StackItem>
                 <StackItem>{t("overview-v2:rhocMainText")}</StackItem>

--- a/src/AppServices/OverviewPageV3.tsx
+++ b/src/AppServices/OverviewPageV3.tsx
@@ -247,7 +247,6 @@ export const OverviewPageV3: FunctionComponent<OverviewPageV3Props> = ({
                     <Label color="blue">
                       {t("overview-v3:applicationService")}
                     </Label>
-                    <Label>{t("overview-v3:servicePreview")}</Label>
                   </LabelGroup>
                 </StackItem>
                 <StackItem>{t("overview-v3:rhocMainText")}</StackItem>

--- a/src/AppServices/OverviewPageV4.tsx
+++ b/src/AppServices/OverviewPageV4.tsx
@@ -299,7 +299,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
                     <Label color="blue">
                       {t("overview-v4:applicationService")}
                     </Label>
-                    <Label>{t("overview-v4:servicePreview")}</Label>
                   </LabelGroup>
                 </StackItem>
                 <StackItem>{t("overview-v4:rhocMainText")}</StackItem>

--- a/src/AppServices/__snapshots__/OverviewPageV2.test.tsx.snap
+++ b/src/AppServices/__snapshots__/OverviewPageV2.test.tsx.snap
@@ -505,19 +505,6 @@ exports[`OverviewPage renders 1`] = `
                             </span>
                           </span>
                         </li>
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Service Preview
-                            </span>
-                          </span>
-                        </li>
                       </ul>
                     </div>
                   </div>

--- a/src/AppServices/__snapshots__/OverviewPageV4.test.tsx.snap
+++ b/src/AppServices/__snapshots__/OverviewPageV4.test.tsx.snap
@@ -615,19 +615,6 @@ exports[`OverviewPage renders 1`] = `
                             </span>
                           </span>
                         </li>
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Service Preview
-                            </span>
-                          </span>
-                        </li>
                       </ul>
                     </div>
                   </div>


### PR DESCRIPTION
This change removes the service preview label from the Connectors service card.

from:

<img width="308" alt="image-2023-01-19-11-11-51-367" src="https://user-images.githubusercontent.com/351660/213730827-1c134e69-7bb5-43ec-8d37-cd3ec16abb22.png">

to:

![Screenshot from 2023-01-20 10-03-59](https://user-images.githubusercontent.com/351660/213730873-c5f4089f-8ba3-45d5-bdbd-86ece1bd4f6d.png)
