### PR TITLE
fix: Remove labels and groups from cards

### DIFF
--- a/src/AppServices/OverviewPageV4.tsx
+++ b/src/AppServices/OverviewPageV4.tsx
@@ -8,8 +8,6 @@ import {
   CardHeaderMain,
   CardTitle,
   Grid,
-  Label,
-  LabelGroup,
   Stack,
   StackItem,
   Title,
@@ -96,14 +94,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="blue">
-                      {t("overview-v4:applicationService")}
-                    </Label>
-                    <Label>{t("overview-v4:servicePreview")}</Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:rhoapidesignerMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:rhoapidesignerSecondaryText")}
@@ -145,13 +135,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="blue">
-                      {t("overview-v4:applicationService")}
-                    </Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:rhoamMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:rhoamSecondaryText")}{" "}
@@ -202,14 +185,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="blue">
-                      {t("overview-v4:applicationService")}
-                    </Label>
-                    <Label color="green">{t("overview-v4:dataService")}</Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:rhosakMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:rhosakSecondaryText")}
@@ -246,13 +221,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="blue">
-                      {t("overview-v4:applicationService")}
-                    </Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:rhosrMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:rhosrSecondaryText")}
@@ -294,13 +262,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="blue">
-                      {t("overview-v4:applicationService")}
-                    </Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:rhocMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:rhocSecondaryText")}{" "}
@@ -349,12 +310,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="green">{t("overview:dataService")}</Label>
-                    <Label>{t("overview-v4:servicePreview")}</Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:dbaasMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:dbaasSecondaryText")}{" "}
@@ -406,12 +361,6 @@ export const OverviewPageV4: FunctionComponent<OverviewPageV4Props> = ({
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <LabelGroup>
-                    <Label color="green">{t("overview-v4:dataService")}</Label>
-                    <Label>{t("overview-v4:fieldTrial")}</Label>
-                  </LabelGroup>
-                </StackItem>
                 <StackItem>{t("overview-v4:rhodsMainText")}</StackItem>
                 <StackItem className="pf-u-color-200">
                   {t("overview-v4:rhodsSecondaryText")}{" "}

--- a/src/AppServices/__snapshots__/OverviewPageV4.test.tsx.snap
+++ b/src/AppServices/__snapshots__/OverviewPageV4.test.tsx.snap
@@ -126,51 +126,6 @@ exports[`OverviewPage renders 1`] = `
                 class="pf-l-stack pf-m-gutter"
               >
                 <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-blue"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Application service
-                            </span>
-                          </span>
-                        </li>
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Service Preview
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-                <div
                   class="pf-l-stack__item"
                 >
                   API Designer provides application developers with a visual editor to create, import, edit, and manage API definitions and event schemas.
@@ -236,38 +191,6 @@ exports[`OverviewPage renders 1`] = `
               <div
                 class="pf-l-stack pf-m-gutter"
               >
-                <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-blue"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Application service
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
                 <div
                   class="pf-l-stack__item"
                 >
@@ -379,51 +302,6 @@ exports[`OverviewPage renders 1`] = `
                 class="pf-l-stack pf-m-gutter"
               >
                 <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-blue"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Application service
-                            </span>
-                          </span>
-                        </li>
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-green"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Data service
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-                <div
                   class="pf-l-stack__item"
                 >
                   Streams for Apache Kafka enables IT development teams to capture, process, and stream real-time data across hybrid cloud environments.
@@ -490,38 +368,6 @@ exports[`OverviewPage renders 1`] = `
                 class="pf-l-stack pf-m-gutter"
               >
                 <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-blue"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Application service
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-                <div
                   class="pf-l-stack__item"
                 >
                   Service Registry provides a metadata layer for developers and applications to publish, discover and evolve schema definitions and API designs.
@@ -587,38 +433,6 @@ exports[`OverviewPage renders 1`] = `
               <div
                 class="pf-l-stack pf-m-gutter"
               >
-                <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-blue"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Application service
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
                 <div
                   class="pf-l-stack__item"
                 >
@@ -714,51 +528,6 @@ exports[`OverviewPage renders 1`] = `
               <div
                 class="pf-l-stack pf-m-gutter"
               >
-                <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-green"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Data service
-                            </span>
-                          </span>
-                        </li>
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Service Preview
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
                 <div
                   class="pf-l-stack__item"
                 >
@@ -870,51 +639,6 @@ exports[`OverviewPage renders 1`] = `
               <div
                 class="pf-l-stack pf-m-gutter"
               >
-                <div
-                  class="pf-l-stack__item pf-u-mb-lg"
-                >
-                  <div
-                    class="pf-c-label-group"
-                  >
-                    <div
-                      class="pf-c-label-group__main"
-                    >
-                      
-                      <ul
-                        aria-label="Label group category"
-                        class="pf-c-label-group__list"
-                        role="list"
-                      >
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label pf-m-green"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Data service
-                            </span>
-                          </span>
-                        </li>
-                        <li
-                          class="pf-c-label-group__list-item"
-                        >
-                          <span
-                            class="pf-c-label"
-                          >
-                            <span
-                              class="pf-c-label__content"
-                            >
-                              Field trial
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
                 <div
                   class="pf-l-stack__item"
                 >


### PR DESCRIPTION
We have a request from the consoledot team and execs to remove the labels since they are outdated. This page will likely be going away within the next few months so this is just a quick fix to remove outdated info.
