### PR TITLE
chore: Add props for shared async select

### DIFF
--- a/src/Kafka/ManageKafkaPermissions/components/ResourceName.stories.tsx
+++ b/src/Kafka/ManageKafkaPermissions/components/ResourceName.stories.tsx
@@ -29,6 +29,10 @@ const Template: ComponentStory<typeof ResourceName> = (args) => (
 
 export const InvalidTopicName = Template.bind({});
 InvalidTopicName.args = { resourceType: "topic" };
+InvalidTopicName.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(await canvas.findByPlaceholderText("Enter name"), "..");
+};
 
 InvalidTopicName.parameters = {
   docs: {

--- a/src/Kafka/ManageKafkaPermissions/components/__snapshots__/ConsumeTopicShortcut.test.tsx.snap
+++ b/src/Kafka/ManageKafkaPermissions/components/__snapshots__/ConsumeTopicShortcut.test.tsx.snap
@@ -204,7 +204,6 @@ exports[`Consume Topic shortcut permissions should render a permissions table an
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-7"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -399,7 +398,6 @@ exports[`Consume Topic shortcut permissions should render a permissions table an
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-8"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -713,7 +711,6 @@ exports[`Consume Topic shortcut permissions should render a permissions table an
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-5"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -908,7 +905,6 @@ exports[`Consume Topic shortcut permissions should render a permissions table an
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-6"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -1187,7 +1183,6 @@ exports[`Consume Topic shortcut permissions should render a permissions table wi
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-3"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -1382,7 +1377,6 @@ exports[`Consume Topic shortcut permissions should render a permissions table wi
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-4"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -1662,7 +1656,6 @@ exports[`Consume Topic shortcut permissions should render a shortcut permissions
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-1"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"
@@ -1881,7 +1874,6 @@ exports[`Consume Topic shortcut permissions should render a shortcut permissions
                     data-ouia-component-id="OUIA-Generated-Select-typeahead-2"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
-                    style="width: 170px;"
                   >
                     <div
                       aria-describedby="resource-name"

--- a/src/Kafka/ManageKafkaPermissions/components/__snapshots__/ProduceTopicShortcut.test.tsx.snap
+++ b/src/Kafka/ManageKafkaPermissions/components/__snapshots__/ProduceTopicShortcut.test.tsx.snap
@@ -200,7 +200,6 @@ exports[`Produce topic shortcut should render a shortcuts table with prefix rule
                   data-ouia-component-id="OUIA-Generated-Select-typeahead-2"
                   data-ouia-component-type="PF4/Select"
                   data-ouia-safe="true"
-                  style="width: 170px;"
                 >
                   <div
                     aria-describedby="resource-name"
@@ -536,7 +535,6 @@ exports[`Produce topic shortcut should render a shortcuts table with table heade
                   data-ouia-component-id="OUIA-Generated-Select-typeahead-3"
                   data-ouia-component-type="PF4/Select"
                   data-ouia-safe="true"
-                  style="width: 170px;"
                 >
                   <div
                     aria-describedby="resource-name"
@@ -837,7 +835,6 @@ exports[`Produce topic shortcut should render a shortcuts table without a header
                   data-ouia-component-id="OUIA-Generated-Select-typeahead-1"
                   data-ouia-component-type="PF4/Select"
                   data-ouia-safe="true"
-                  style="width: 170px;"
                 >
                   <div
                     aria-describedby="resource-name"

--- a/src/shared/AsyncTypeaheadSelect/AsyncTypeaheadSelect.tsx
+++ b/src/shared/AsyncTypeaheadSelect/AsyncTypeaheadSelect.tsx
@@ -30,6 +30,9 @@ export type AsyncTypeaheadSelectProps = {
   submitted?: boolean;
   required?: boolean;
   createText?: string;
+  isInputValuePersisted?: boolean;
+  isInputFilterPersisted?: boolean;
+  width?: number;
 };
 
 export const AsyncTypeaheadSelect: VFC<AsyncTypeaheadSelectProps> = ({
@@ -43,6 +46,9 @@ export const AsyncTypeaheadSelect: VFC<AsyncTypeaheadSelectProps> = ({
   submitted,
   required,
   createText,
+  isInputValuePersisted = false,
+  isInputFilterPersisted = false,
+  width,
 }) => {
   const { t } = useTranslation(["common"]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -133,6 +139,8 @@ export const AsyncTypeaheadSelect: VFC<AsyncTypeaheadSelectProps> = ({
         onFilter={(_, value) => onFilter(value)}
         isCreatable={true}
         menuAppendTo={document.body}
+        isInputFilterPersisted={isInputFilterPersisted}
+        isInputValuePersisted={isInputValuePersisted}
         validated={
           submitted &&
           (((filterValue == "" || filterValue == undefined) && value == "") ||
@@ -141,7 +149,7 @@ export const AsyncTypeaheadSelect: VFC<AsyncTypeaheadSelectProps> = ({
             : formValidation
         }
         maxHeight={400}
-        width={170}
+        width={width}
         createText={createText}
       >
         {onFilter()}


### PR DESCRIPTION
- We need to persist the input value of the component on blur. Add props to give the user freedom to decide how he wants to consume this component. 

- We don't need to hard code the width for a shared component 

Updated snapshots since the hard coded width value was removed. Tested on storybook and everything works and looks as expected